### PR TITLE
Auth + 2FA, sidebar nav, and rebuilt operations dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Stack
+
+Spring Boot 3.2.1 on Java 17, server-side rendered with Thymeleaf, persisted to an in-memory H2 database. Maven build via the bundled wrapper. Lombok generates entity boilerplate (`@Data`, `@Builder`, `@AllArgsConstructor`, `@NoArgsConstructor`). Spring Security with form login + email-based 2FA + password reset; thymeleaf-extras-springsecurity6 is on the classpath for `sec:authorize`.
+
+## Commands
+
+```bash
+./mvnw spring-boot:run                                    # run app on :8080
+./mvnw test                                               # run all tests
+./mvnw -Dtest=TrieTest test                               # run one test class
+./mvnw -Dtest=TrieTest#getWordList test                   # run one test method
+./mvnw clean package                                      # build jar to target/
+```
+
+H2 console: `http://localhost:8080/h2-console` (JDBC URL `jdbc:h2:mem:testdb`, no auth needed — `application.properties` enables the console and uses `ddl-auto=update`).
+
+## Architecture
+
+Classic Spring MVC layering, packaged under `com.example.warehouseManagement`:
+
+- `Domains/` — JPA entities (`@Entity` + Lombok). Status enums live as nested types on their owning entity (`SalesOrder.SoStatus`, `PurchaseOrder.PoStatus`, `GoodsReceiptNote.GrnStatus`, `PickingJob.PjStatus`).
+- `Domains/DTOs/` — Projection DTOs returned by native queries, plus form-binding DTOs.
+- `Domains/Exceptions/` — Domain exceptions thrown from services and caught in controllers to drive redirects (e.g. `ShippedOrderModificationException`).
+- `Repositories/` — `CrudRepository` interfaces. Many methods are `@Query(nativeQuery = true)` returning DTO projections. Queries use **H2-specific SQL** (`TO_CHAR`, `DATEDIFF`, `FORMATDATETIME`, `DATEADD`, `EXTRACT`); changing databases will require rewriting them.
+- `Services/` — Each capability is split into a `FooService` interface and `FooServiceImpl`. Wire services together (not repositories) when crossing capabilities.
+- `Controllers/` — Thymeleaf-returning controllers (return view names, not `@RestController`). All controllers `@RequestMapping(value = "/")` except `ReportController` (`/reports`). Each controller defines path constants at the top.
+- `Bootstrap/Bootstrap.java` — `CommandLineRunner` that seeds customers, vendors, items, prices, costs, warehouse sections, and sample sales/purchase orders on every startup (because the DB is in-memory). Touch this when changing entity shape or when reproducing data-dependent bugs.
+- `DSA/` (`Trie`, `BinarySearchTree`) and `Util/Counter` — standalone utilities. As of now, `Trie` and `BinarySearchTree` are only referenced by tests, not by main code.
+- `Security/` — `SecurityConfig` (filter chain, BCrypt) and `TwoFactorAuthenticationSuccessHandler` (post-password-auth hook).
+
+### Auth flow
+
+- `UserService` doubles as `UserDetailsService`. The `User` entity stores the 2FA code (BCrypt-hashed) and password-reset token, each with an expiry timestamp — there is no separate token table.
+- Form login posts to `/login`. After Spring Security validates credentials, `TwoFactorAuthenticationSuccessHandler` checks `user.twoFactorEnabled`:
+  - If on: generates a 6-digit code, emails it, **overwrites the session's saved `SecurityContext` with an empty one** via `SecurityContextRepository.saveContext(...)`, sets `PENDING_2FA_USERNAME` on the session, and redirects to `/verify-2fa`. The overwrite is required — clearing only `SecurityContextHolder` is not enough because `UsernamePasswordAuthenticationFilter` already persisted the authenticated context to the session before the success handler runs. Removing it would re-open a 2FA bypass.
+  - If off: redirects to `/`.
+- `/verify-2fa` POST validates the code, builds a fresh `UsernamePasswordAuthenticationToken`, and writes it back via `SecurityContextRepository` so subsequent requests are fully authenticated.
+- `EmailServiceImpl` always tries `JavaMailSender.send(...)`; if SMTP isn't configured (default in dev) it catches `MailException` and **logs the full email body** so codes and reset links can be copied from the console. Don't remove this fallback without providing an alternative dev path.
+- Forgot-password always returns the same banner regardless of whether the email matched a user (no enumeration).
+- `/admin/**` requires `ROLE_ADMIN`. The H2 console under `/h2-console/**` is permit-all with `frameOptions=sameOrigin` and CSRF disabled for that path only.
+- Seed users (created on each in-memory startup by `Bootstrap.seedUsers`): `admin` / `Password123!` (ADMIN, no 2FA) and `manager` / `Password123!` (USER, 2FA on). Change these before any non-dev deployment.
+
+### Controller form conventions
+
+Forms that build up a list of lines (sales orders, purchase orders, GRNs) all use the same pattern: a single endpoint differentiated by a request parameter, returning the same template each time except for save.
+
+```java
+@PostMapping(value = NEW_SALES_ORDER_PATH, params = "addRow")     // append a blank line
+@PostMapping(value = NEW_SALES_ORDER_PATH, params = "removeRow")  // remove line at index
+@PostMapping(value = NEW_SALES_ORDER_PATH, params = "save")       // persist and redirect
+```
+
+After mutations, controllers redirect to a list URL with a result flag in the query string (`?added`, `?updated`, `?notFound`, `?salesOrderDeleted`, `?cannotBeUpdated`, `?failedToDelete`). Templates read these flags to render banners. Preserve this pattern when adding new flows — don't introduce flash attributes or JSON responses without a reason.
+
+### Core domain workflow
+
+The entities cooperate as a small WMS pipeline; understanding this saves cross-file reading:
+
+1. **Inbound**: `PurchaseOrder` → on receipt, a `GoodsReceiptNote` is opened against it → fulfilling the GRN creates `Stock` rows on a floor `WarehouseSection` (constant `PutAwayController.FLOOR = "00-00-0-0"`).
+2. **Put-away**: `PutAwayController` moves `Stock` from the floor section to a real `WarehouseSection`.
+3. **Outbound**: Saving a `SalesOrder` (`SalesOrderServiceImpl.save`) **also** creates a `PickingJob` with `PickingJobLine`s mirroring each `SalesOrderLine`. Fulfilling the picking job decrements `Stock`, writes an `Invoice`, and creates `Backorder`s for unmet quantities. Status transitions: `PENDING` → `PARTIALLY_SHIPPED` → `SHIPPED`.
+4. **Pricing**: `ItemPrice` and `ItemCost` are time-versioned per item — order lines snapshot the *current* price/cost via `findCurrentItemPriceByItemId` at save time so historical totals stay correct.
+
+A shipped sales order is immutable: `SalesOrderServiceImpl.updateById` throws `ShippedOrderModificationException`. Honor this invariant — don't add bypasses.
+
+## Gotchas
+
+- `ddl-auto=update` plus the always-on `Bootstrap` runner means schema changes are picked up on restart but old seed data persists only for the lifetime of the JVM. Restart the app to reset state.
+- When adding an entity field, check `Bootstrap.java` — it builds entities by hand and will fail to compile if required fields are added without defaults.
+- Native queries return DTO interfaces (projections). Don't replace them with entity returns without updating the SQL `AS` aliases to match getters.
+- `pom.xml` excludes Lombok from the Spring Boot fat jar build — this is intentional; don't "fix" it.

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,22 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
 			<scope>provided</scope>

--- a/src/main/java/com/example/warehouseManagement/Bootstrap/Bootstrap.java
+++ b/src/main/java/com/example/warehouseManagement/Bootstrap/Bootstrap.java
@@ -2,6 +2,7 @@ package com.example.warehouseManagement.Bootstrap;
 
 import java.security.SecureRandom;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -133,6 +134,14 @@ public class Bootstrap implements CommandLineRunner {
 
         // Variables
         Random random = new SecureRandom();
+        // Seed-data window: Jan 1 of the current year through the last day of the
+        // current month. This keeps dashboard queries (e.g. "last three months sales"
+        // against CURRENT_DATE()) populated as the system clock moves forward.
+        final LocalDate today = LocalDate.now();
+        final LocalDate yearStart = today.with(TemporalAdjusters.firstDayOfYear());
+        final LocalDate cutoff = today.with(TemporalAdjusters.lastDayOfMonth());
+        final long startEpoch = yearStart.toEpochDay();
+        final long endEpochExclusive = cutoff.toEpochDay() + 1;
         int VENDORS = 5, CUSTOMERS = 10, SALES_ORDER = 20, PURCHASE_ORDER = 30;
         List<Vendor> savedVendors = new ArrayList<>();
         List<Customer> savedCustomers = new ArrayList<>();
@@ -164,12 +173,14 @@ public class Bootstrap implements CommandLineRunner {
                 // Add vendos to the savedProducts objects
                 item.setVendor(currentVendor);
                 Item savedItem = itemRepository.save(item);
-                ItemPrice itemPrice = ItemPrice.builder().start(LocalDate.of(2023, 1, 1))
+                LocalDate priceStart = yearStart;
+                LocalDate priceEnd = LocalDate.of(today.getYear(), 12, 31);
+                ItemPrice itemPrice = ItemPrice.builder().start(priceStart)
                         .salesOrderLine(new ArrayList<>())
-                        .end(LocalDate.of(2023, 12, 31)).price(itemInfo.getSalesPrice()).item(savedItem).build();
-                ItemCost itemCost = ItemCost.builder().start(LocalDate.of(2023, 1, 1))
+                        .end(priceEnd).price(itemInfo.getSalesPrice()).item(savedItem).build();
+                ItemCost itemCost = ItemCost.builder().start(priceStart)
                         .purchaseOrderLine(new ArrayList<>(i))
-                        .end(LocalDate.of(2023, 12, 31)).cost(itemInfo.getCost()).item(savedItem).build();
+                        .end(priceEnd).cost(itemInfo.getCost()).item(savedItem).build();
                 ItemPrice savedItemPrice = itemPriceRepository.save(itemPrice);
                 ItemCost savedItemCost = itemCostRepository.save(itemCost);
                 // salesPrices.add(savedItemPrice);
@@ -194,10 +205,7 @@ public class Bootstrap implements CommandLineRunner {
 
         for (Vendor vendor : savedVendors) {
             for (int i = 0; i < PURCHASE_ORDER; i++) {
-                int month = random.nextInt(1, 12);
-                int day = (month == 2) ? random.nextInt(1, 28) : random.nextInt(1, 30);
-                int year = 2023;
-                LocalDate date = LocalDate.of(year, month, day);
+                LocalDate date = LocalDate.ofEpochDay(random.nextLong(startEpoch, endEpochExclusive));
                 int purchaseOrderLines = random.nextInt(3, 20);
                 int orderStatus = random.nextInt(3);
                 // adds savedCustomer to the purchase order
@@ -352,10 +360,7 @@ public class Bootstrap implements CommandLineRunner {
         // TC(MSO)
         for (Customer customer : savedCustomers) {
             for (int i = 0; i < SALES_ORDER; i++) {
-                int month = random.nextInt(1, 13); // to include december
-                int day = (month == 2) ? random.nextInt(1, 28) : random.nextInt(1, 30);
-                int year = 2023;
-                LocalDate date = LocalDate.of(year, month, day);
+                LocalDate date = LocalDate.ofEpochDay(random.nextLong(startEpoch, endEpochExclusive));
                 int salesOrderLines = random.nextInt(3, 20);
                 int orderStatus = random.nextInt(3);
                 // adds savedCustomer to the savedSalesOrder

--- a/src/main/java/com/example/warehouseManagement/Bootstrap/Bootstrap.java
+++ b/src/main/java/com/example/warehouseManagement/Bootstrap/Bootstrap.java
@@ -57,6 +57,10 @@ import com.example.warehouseManagement.Repositories.StockRepository;
 import com.example.warehouseManagement.Repositories.VendorRepository;
 import com.example.warehouseManagement.Repositories.WarehouseRepository;
 import com.example.warehouseManagement.Repositories.WarehouseSectionRepository;
+import com.example.warehouseManagement.Domains.User;
+import com.example.warehouseManagement.Domains.User.Role;
+import com.example.warehouseManagement.Repositories.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Component
 public class Bootstrap implements CommandLineRunner {
@@ -80,6 +84,8 @@ public class Bootstrap implements CommandLineRunner {
     private final InvoiceRepository invoiceRepository;
     private final InvoiceLineRepository invoiceLineRepository;
     private final BackorderRepository backorderRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public Bootstrap(CustomerRepository customerRepository, ItemRepository itemRepository,
             VendorRepository vendorRepository, SalesOrderRepository salesOrderRepository,
@@ -91,7 +97,8 @@ public class Bootstrap implements CommandLineRunner {
             ItemPriceRepository itemPriceRepository, ItemCostRepository itemCostRepository,
             PickingJobRepository pickingJobRepository, PickingJobLineRepository pickingJobLineRepository,
             InvoiceRepository invoiceRepository, InvoiceLineRepository invoiceLineRepository,
-            BackorderRepository backorderRepository) {
+            BackorderRepository backorderRepository,
+            UserRepository userRepository, PasswordEncoder passwordEncoder) {
         this.customerRepository = customerRepository;
         this.itemRepository = itemRepository;
         this.vendorRepository = vendorRepository;
@@ -111,6 +118,8 @@ public class Bootstrap implements CommandLineRunner {
         this.invoiceRepository = invoiceRepository;
         this.invoiceLineRepository = invoiceLineRepository;
         this.backorderRepository = backorderRepository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     /**
@@ -119,6 +128,8 @@ public class Bootstrap implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
+
+        seedUsers();
 
         // Variables
         Random random = new SecureRandom();
@@ -445,6 +456,38 @@ public class Bootstrap implements CommandLineRunner {
         System.out.printf("Invocies: %d\n", invoiceRepository.count());
         System.out.printf("Backorders: %d\n", backorderRepository.count());
 
+    }
+
+    /**
+     * Seeds an admin and a 2FA-enabled user on every startup (DB is in-memory).
+     * <p>
+     * Default credentials (DEV ONLY — change for production):
+     * <ul>
+     *   <li>admin / Password123! (no 2FA) — ROLE_ADMIN</li>
+     *   <li>manager / Password123! (2FA on) — ROLE_USER</li>
+     * </ul>
+     */
+    private void seedUsers() {
+        if (userRepository.count() > 0) {
+            return;
+        }
+        userRepository.save(User.builder()
+                .username("admin")
+                .email("admin@example.com")
+                .password(passwordEncoder.encode("Password123!"))
+                .role(Role.ADMIN)
+                .enabled(true)
+                .twoFactorEnabled(false)
+                .build());
+        userRepository.save(User.builder()
+                .username("manager")
+                .email("manager@example.com")
+                .password(passwordEncoder.encode("Password123!"))
+                .role(Role.USER)
+                .enabled(true)
+                .twoFactorEnabled(true)
+                .build());
+        System.out.println("Seeded users: admin (ADMIN, no 2FA) and manager (USER, 2FA enabled). Password: Password123!");
     }
 
 }

--- a/src/main/java/com/example/warehouseManagement/Controllers/AdminUserController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/AdminUserController.java
@@ -1,0 +1,148 @@
+package com.example.warehouseManagement.Controllers;
+
+import java.util.Optional;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.example.warehouseManagement.Domains.User;
+import com.example.warehouseManagement.Domains.User.Role;
+import com.example.warehouseManagement.Domains.DTOs.UserFormDto;
+import com.example.warehouseManagement.Domains.Exceptions.DuplicateUserException;
+import com.example.warehouseManagement.Domains.Exceptions.UserNotFoundException;
+import com.example.warehouseManagement.Services.UserService;
+
+import jakarta.validation.Valid;
+
+@Controller
+@RequestMapping("/admin/users")
+public class AdminUserController {
+
+    private static final String NEW_USER_PATH = "/new";
+    private static final String USER_ID_PATH = "/{userId}";
+    private static final String UPDATE_USER_ID_PATH = USER_ID_PATH + "/update";
+
+    private final UserService userService;
+
+    public AdminUserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public String listUsers(Model model) {
+        model.addAttribute("title", "Users");
+        model.addAttribute("users", userService.findAll());
+        return "admin/users";
+    }
+
+    @GetMapping(NEW_USER_PATH)
+    public String newUserForm(Model model) {
+        model.addAttribute("title", "New user");
+        model.addAttribute("userForm", UserFormDto.builder().role(Role.USER).enabled(true).build());
+        model.addAttribute("roles", Role.values());
+        model.addAttribute("isCreate", true);
+        return "admin/newUserForm";
+    }
+
+    @PostMapping(NEW_USER_PATH)
+    public String createUser(@Valid @ModelAttribute("userForm") UserFormDto dto,
+                             BindingResult binding,
+                             Model model) {
+        if (binding.hasErrors()) {
+            return rerenderForm(model, "admin/newUserForm", "New user", true);
+        }
+        if (dto.getPassword() == null || dto.getPassword().isBlank()) {
+            binding.rejectValue("password", "required", "Password is required");
+            return rerenderForm(model, "admin/newUserForm", "New user", true);
+        }
+        try {
+            User saved = userService.create(dto);
+            return "redirect:/admin/users/" + saved.getId() + "?created";
+        } catch (DuplicateUserException e) {
+            binding.reject("duplicate", e.getMessage());
+            return rerenderForm(model, "admin/newUserForm", "New user", true);
+        }
+    }
+
+    @GetMapping(USER_ID_PATH)
+    public String userDetails(@PathVariable Long userId, Model model) {
+        Optional<User> user = userService.findById(userId);
+        if (user.isEmpty()) {
+            return "redirect:/admin/users?notFound";
+        }
+        model.addAttribute("title", "User");
+        model.addAttribute("user", user.get());
+        return "admin/userDetails";
+    }
+
+    @GetMapping(UPDATE_USER_ID_PATH)
+    public String updateUserForm(@PathVariable Long userId, Model model) {
+        Optional<User> user = userService.findById(userId);
+        if (user.isEmpty()) {
+            return "redirect:/admin/users?notFound";
+        }
+        User u = user.get();
+        UserFormDto dto = UserFormDto.builder()
+                .id(u.getId())
+                .username(u.getUsername())
+                .email(u.getEmail())
+                .role(u.getRole())
+                .enabled(u.isEnabled())
+                .twoFactorEnabled(u.isTwoFactorEnabled())
+                .build();
+        model.addAttribute("title", "Edit user");
+        model.addAttribute("userForm", dto);
+        model.addAttribute("roles", Role.values());
+        model.addAttribute("isCreate", false);
+        return "admin/updateUserForm";
+    }
+
+    @PostMapping(UPDATE_USER_ID_PATH)
+    public String updateUser(@PathVariable Long userId,
+                             @Valid @ModelAttribute("userForm") UserFormDto dto,
+                             BindingResult binding,
+                             Model model) {
+        if (binding.hasErrors()) {
+            return rerenderForm(model, "admin/updateUserForm", "Edit user", false);
+        }
+        try {
+            userService.update(userId, dto);
+            return "redirect:/admin/users/" + userId + "?updated";
+        } catch (UserNotFoundException e) {
+            return "redirect:/admin/users?notFound";
+        } catch (DuplicateUserException e) {
+            binding.reject("duplicate", e.getMessage());
+            return rerenderForm(model, "admin/updateUserForm", "Edit user", false);
+        }
+    }
+
+    @PostMapping(value = USER_ID_PATH, params = "delete")
+    public String deleteUser(@PathVariable Long userId,
+                             @AuthenticationPrincipal UserDetails principal) {
+        // Don't let an admin delete themselves and lock the system out.
+        Optional<User> user = userService.findById(userId);
+        if (user.isEmpty()) {
+            return "redirect:/admin/users?notFound";
+        }
+        if (principal != null && user.get().getUsername().equals(principal.getUsername())) {
+            return "redirect:/admin/users/" + userId + "?cannotDeleteSelf";
+        }
+        userService.delete(userId);
+        return "redirect:/admin/users?deleted";
+    }
+
+    private String rerenderForm(Model model, String view, String title, boolean isCreate) {
+        model.addAttribute("title", title);
+        model.addAttribute("roles", Role.values());
+        model.addAttribute("isCreate", isCreate);
+        return view;
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Controllers/AuthController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/AuthController.java
@@ -1,0 +1,167 @@
+package com.example.warehouseManagement.Controllers;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.example.warehouseManagement.Domains.User;
+import com.example.warehouseManagement.Domains.DTOs.ForgotPasswordDto;
+import com.example.warehouseManagement.Domains.DTOs.ResetPasswordDto;
+import com.example.warehouseManagement.Domains.DTOs.TwoFactorVerificationDto;
+import com.example.warehouseManagement.Security.TwoFactorAuthenticationSuccessHandler;
+import com.example.warehouseManagement.Services.EmailService;
+import com.example.warehouseManagement.Services.UserService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+
+@Controller
+public class AuthController {
+
+    private final UserService userService;
+    private final EmailService emailService;
+    private final SecurityContextRepository securityContextRepository;
+    private final String baseUrl;
+
+    public AuthController(UserService userService,
+                          EmailService emailService,
+                          SecurityContextRepository securityContextRepository,
+                          @Value("${app.auth.base-url}") String baseUrl) {
+        this.userService = userService;
+        this.emailService = emailService;
+        this.securityContextRepository = securityContextRepository;
+        this.baseUrl = baseUrl;
+    }
+
+    @GetMapping("/login")
+    public String loginPage(Model model) {
+        model.addAttribute("title", "Sign in");
+        return "auth/login";
+    }
+
+    // ----- 2FA -----
+
+    @GetMapping("/verify-2fa")
+    public String verify2faForm(HttpSession session, Model model) {
+        if (session.getAttribute(TwoFactorAuthenticationSuccessHandler.PENDING_2FA_USERNAME) == null) {
+            return "redirect:/login";
+        }
+        model.addAttribute("title", "Verify");
+        model.addAttribute("twoFactor", new TwoFactorVerificationDto());
+        return "auth/verify2fa";
+    }
+
+    @PostMapping("/verify-2fa")
+    public String verify2faSubmit(@Validated @ModelAttribute("twoFactor") TwoFactorVerificationDto dto,
+                                  BindingResult binding,
+                                  HttpServletRequest request,
+                                  HttpServletResponse response,
+                                  HttpSession session,
+                                  Model model) {
+        String username = (String) session.getAttribute(TwoFactorAuthenticationSuccessHandler.PENDING_2FA_USERNAME);
+        if (username == null) {
+            return "redirect:/login";
+        }
+        if (binding.hasErrors()) {
+            model.addAttribute("title", "Verify");
+            return "auth/verify2fa";
+        }
+
+        User user = userService.findByUsername(username).orElse(null);
+        if (user == null || !user.isEnabled() || !userService.verifyTwoFactorCode(user, dto.getCode())) {
+            session.removeAttribute(TwoFactorAuthenticationSuccessHandler.PENDING_2FA_USERNAME);
+            return "redirect:/login?invalidCode";
+        }
+
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                user.getUsername(), null, authorities);
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(auth);
+        SecurityContextHolder.setContext(context);
+        securityContextRepository.saveContext(context, request, response);
+
+        session.removeAttribute(TwoFactorAuthenticationSuccessHandler.PENDING_2FA_USERNAME);
+        userService.recordSuccessfulLogin(user);
+        return "redirect:/";
+    }
+
+    // ----- Forgot password -----
+
+    @GetMapping("/forgot-password")
+    public String forgotPasswordForm(Model model) {
+        model.addAttribute("title", "Forgot password");
+        model.addAttribute("forgotPassword", new ForgotPasswordDto());
+        return "auth/forgotPassword";
+    }
+
+    @PostMapping("/forgot-password")
+    public String forgotPasswordSubmit(@Valid @ModelAttribute("forgotPassword") ForgotPasswordDto dto,
+                                       BindingResult binding,
+                                       Model model) {
+        if (binding.hasErrors()) {
+            model.addAttribute("title", "Forgot password");
+            return "auth/forgotPassword";
+        }
+        // Always show the same banner — never leak whether the email exists.
+        userService.findByEmail(dto.getEmail()).ifPresent(user -> {
+            String token = userService.generatePasswordResetToken(user);
+            String url = baseUrl + "/reset-password?token=" + token;
+            emailService.sendPasswordResetLink(user.getEmail(), url);
+        });
+        return "redirect:/forgot-password?submitted";
+    }
+
+    // ----- Reset password -----
+
+    @GetMapping("/reset-password")
+    public String resetPasswordForm(@RequestParam(required = false) String token, Model model) {
+        if (token == null || userService.findByValidResetToken(token).isEmpty()) {
+            return "redirect:/login?invalidResetToken";
+        }
+        ResetPasswordDto dto = new ResetPasswordDto();
+        dto.setToken(token);
+        model.addAttribute("title", "Reset password");
+        model.addAttribute("resetPassword", dto);
+        return "auth/resetPassword";
+    }
+
+    @PostMapping("/reset-password")
+    public String resetPasswordSubmit(@Valid @ModelAttribute("resetPassword") ResetPasswordDto dto,
+                                      BindingResult binding,
+                                      Model model) {
+        if (binding.hasErrors()) {
+            model.addAttribute("title", "Reset password");
+            return "auth/resetPassword";
+        }
+        if (!dto.getPassword().equals(dto.getConfirmPassword())) {
+            binding.rejectValue("confirmPassword", "mismatch", "Passwords do not match");
+            model.addAttribute("title", "Reset password");
+            return "auth/resetPassword";
+        }
+        User user = userService.findByValidResetToken(dto.getToken()).orElse(null);
+        if (user == null) {
+            return "redirect:/login?invalidResetToken";
+        }
+        userService.resetPassword(user, dto.getPassword());
+        return "redirect:/login?passwordReset";
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Controllers/DashBoardController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/DashBoardController.java
@@ -5,42 +5,60 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.example.warehouseManagement.Services.BackorderService;
+import com.example.warehouseManagement.Services.GoodsReceiptNoteService;
+import com.example.warehouseManagement.Services.PickingJobService;
+import com.example.warehouseManagement.Services.PurchaseOrderService;
 import com.example.warehouseManagement.Services.SalesOrderService;
 import com.example.warehouseManagement.Services.StockService;
 
-/**
- * Controller to handle dashboard requests.
- */
 @Controller
 @RequestMapping(value = "/")
 public class DashBoardController {
 
-    // private static final String DASH_BOARD_PATH = "dashboar";
-    private final SalesOrderService salesOrderService; // may need to be changed for invoiced sales orders
+    private final SalesOrderService salesOrderService;
+    private final PurchaseOrderService purchaseOrderService;
     private final StockService stockService;
+    private final BackorderService backorderService;
+    private final GoodsReceiptNoteService goodsReceiptNoteService;
+    private final PickingJobService pickingJobService;
 
-    /**
-     * Constructor to inject the necessary dependencies.
-     *
-     * @param salesOrderService the SalesOrderService dependency
-     * @param stockService      the StockService dependency
-     */
-    public DashBoardController(SalesOrderService salesOrderService, StockService stockService) {
+    public DashBoardController(SalesOrderService salesOrderService,
+                               PurchaseOrderService purchaseOrderService,
+                               StockService stockService,
+                               BackorderService backorderService,
+                               GoodsReceiptNoteService goodsReceiptNoteService,
+                               PickingJobService pickingJobService) {
         this.salesOrderService = salesOrderService;
+        this.purchaseOrderService = purchaseOrderService;
         this.stockService = stockService;
+        this.backorderService = backorderService;
+        this.goodsReceiptNoteService = goodsReceiptNoteService;
+        this.pickingJobService = pickingJobService;
     }
 
-    /**
-     * Handles GET requests for the dashboard.
-     *
-     * @param model the Model object to populate with data for the view
-     * @return the name of the view template to render
-     */
     @GetMapping(value = "/")
     public String getDashBoard(Model model) {
-            model.addAttribute("title", "Dashboard");
-            model.addAttribute("lastThreeMonthsSales", salesOrderService.findLastThreeMonthsSales());
-            model.addAttribute("topFiveMovers", stockService.getTopFiveMovers());
-            return "dashboard/dashboard"; // Returning the view template name
+        model.addAttribute("title", "Dashboard");
+        // Row 1 — KPI cards
+        model.addAttribute("kpiSo",          salesOrderService.findOpenSalesOrdersKpi());
+        model.addAttribute("kpiPo",          purchaseOrderService.findOpenPurchaseOrdersKpi());
+        model.addAttribute("kpiBackorders",  backorderService.findBackorderKpi());
+        model.addAttribute("pendingGrns",    goodsReceiptNoteService.countPending());
+        // Row 2 — inventory snapshot tiles
+        model.addAttribute("inventory",      stockService.findInventorySnapshot());
+        // Row 3 — daily sales trend + ops stats
+        model.addAttribute("dailySales",     salesOrderService.findDailySalesLast30Days());
+        model.addAttribute("pendingPicks",   pickingJobService.countPending());
+        model.addAttribute("stockOnFloor",   stockService.countStockOnFloor());
+        // Row 4 — vendor spend + PO status doughnut
+        model.addAttribute("topVendors",     purchaseOrderService.findTopVendorsBySpendYtd());
+        model.addAttribute("poStatusBuckets",purchaseOrderService.findPoStatusBuckets());
+        // Row 5 — reorder + top movers
+        model.addAttribute("reorderItems",   stockService.findReorderCandidates());
+        model.addAttribute("topFiveMovers",  stockService.getTopFiveMovers());
+        // Row 6 — PO aging
+        model.addAttribute("agingPos",       purchaseOrderService.findAgingPurchaseOrders());
+        return "dashboard/dashboard";
     }
 }

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/AgingPoDto.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/AgingPoDto.java
@@ -1,0 +1,12 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import java.time.LocalDate;
+
+public interface AgingPoDto {
+    Long getId();
+    String getVendorName();
+    LocalDate getDate();
+    Integer getAgeDays();
+    Double getTotal();
+    Integer getStatus();
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/DailySalesDto.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/DailySalesDto.java
@@ -1,0 +1,8 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import java.time.LocalDate;
+
+public interface DailySalesDto {
+    LocalDate getDay();
+    Double getTotal();
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/ForgotPasswordDto.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/ForgotPasswordDto.java
@@ -1,0 +1,16 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ForgotPasswordDto {
+    @NotBlank
+    @Email
+    private String email;
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/InventorySnapshotDto.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/InventorySnapshotDto.java
@@ -1,0 +1,8 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+public interface InventorySnapshotDto {
+    Double getTotalValue();
+    Long getTotalUnits();
+    Long getOosCount();
+    Long getLowStockCount();
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/OpenOrdersKpiDto.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/OpenOrdersKpiDto.java
@@ -1,0 +1,6 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+public interface OpenOrdersKpiDto {
+    Long getCount();
+    Double getTotalValue();
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/PoStatusBucketDto.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/PoStatusBucketDto.java
@@ -1,0 +1,6 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+public interface PoStatusBucketDto {
+    Integer getStatus();
+    Long getCount();
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/ReorderItemDto.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/ReorderItemDto.java
@@ -1,0 +1,11 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+public interface ReorderItemDto {
+    Long getItemId();
+    Integer getSku();
+    String getDescription();
+    String getVendorName();
+    Integer getQtyOnHand();
+    Integer getWeeklyVelocity();
+    Double getWeeksOfInventory();
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/ResetPasswordDto.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/ResetPasswordDto.java
@@ -1,0 +1,23 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResetPasswordDto {
+    @NotBlank
+    private String token;
+
+    @NotBlank
+    @Size(min = 8, max = 128)
+    private String password;
+
+    @NotBlank
+    @Size(min = 8, max = 128)
+    private String confirmPassword;
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/TwoFactorVerificationDto.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/TwoFactorVerificationDto.java
@@ -1,0 +1,16 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TwoFactorVerificationDto {
+    @NotBlank
+    @Size(min = 6, max = 6)
+    private String code;
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/UserFormDto.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/UserFormDto.java
@@ -1,0 +1,41 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import com.example.warehouseManagement.Domains.User.Role;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserFormDto {
+    private Long id;
+
+    @NotBlank
+    @Size(min = 3, max = 64)
+    private String username;
+
+    @NotBlank
+    @Email
+    @Size(max = 254)
+    private String email;
+
+    // Required only on create; ignored on update unless non-blank.
+    @Size(min = 8, max = 128)
+    private String password;
+
+    @Builder.Default
+    private Role role = Role.USER;
+
+    @Builder.Default
+    private boolean enabled = true;
+
+    @Builder.Default
+    private boolean twoFactorEnabled = false;
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/VendorSpendDto.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/VendorSpendDto.java
@@ -1,0 +1,6 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+public interface VendorSpendDto {
+    String getVendorName();
+    Double getTotal();
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/Exceptions/DuplicateUserException.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/Exceptions/DuplicateUserException.java
@@ -1,0 +1,7 @@
+package com.example.warehouseManagement.Domains.Exceptions;
+
+public class DuplicateUserException extends RuntimeException {
+    public DuplicateUserException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/Exceptions/InvalidTokenException.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/Exceptions/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.example.warehouseManagement.Domains.Exceptions;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/Exceptions/UserNotFoundException.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/Exceptions/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.warehouseManagement.Domains.Exceptions;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/User.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/User.java
@@ -1,0 +1,75 @@
+package com.example.warehouseManagement.Domains;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "app_user")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "username", nullable = false, unique = true, length = 64)
+    private String username;
+
+    @Column(name = "email", nullable = false, unique = true, length = 254)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 16)
+    @Builder.Default
+    private Role role = Role.USER;
+
+    @Column(name = "enabled", nullable = false)
+    @Builder.Default
+    private boolean enabled = true;
+
+    @Column(name = "two_factor_enabled", nullable = false)
+    @Builder.Default
+    private boolean twoFactorEnabled = false;
+
+    @Column(name = "two_factor_code")
+    private String twoFactorCode;
+
+    @Column(name = "two_factor_code_expires_at")
+    private Instant twoFactorCodeExpiresAt;
+
+    @Column(name = "password_reset_token")
+    private String passwordResetToken;
+
+    @Column(name = "password_reset_token_expires_at")
+    private Instant passwordResetTokenExpiresAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private Instant createdAt = Instant.now();
+
+    @Column(name = "last_login_at")
+    private Instant lastLoginAt;
+
+    public enum Role {
+        USER,
+        ADMIN
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Repositories/BackorderRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/BackorderRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import com.example.warehouseManagement.Domains.Backorder;
 import com.example.warehouseManagement.Domains.SalesOrder;
 import com.example.warehouseManagement.Domains.DTOs.BackorderDto;
+import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
 
 
 public interface BackorderRepository extends CrudRepository<Backorder, Long> {
@@ -31,6 +32,21 @@ public interface BackorderRepository extends CrudRepository<Backorder, Long> {
         ORDER BY "date"\
         """, nativeQuery = true)
     public List<BackorderDto> findBackordersByYear(@Param("year") int year);
+
+    /**
+     * Dashboard KPI: count + total dollar value of active backorders.
+     * Value is qty × current item price (the price effective today).
+     */
+    @Query(value = """
+      SELECT
+        COUNT(b.id) AS "count",
+        COALESCE(ROUND(SUM(b.qty * ip.price), 2), 0) AS "totalValue"
+      FROM backorder b
+      LEFT JOIN item_price ip ON ip.item_id = b.item_id
+        AND ip.start_date <= CURRENT_DATE()
+        AND ip.end_date >= CURRENT_DATE()
+      """, nativeQuery = true)
+    public OpenOrdersKpiDto findBackorderKpi();
 
     /**
     SELECT

--- a/src/main/java/com/example/warehouseManagement/Repositories/GoodsReceiptNoteRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/GoodsReceiptNoteRepository.java
@@ -8,8 +8,11 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
 import com.example.warehouseManagement.Domains.GoodsReceiptNote;
+import com.example.warehouseManagement.Domains.GoodsReceiptNote.GrnStatus;
 
 public interface GoodsReceiptNoteRepository extends CrudRepository<GoodsReceiptNote, Long> {
+
+    long countByStatus(GrnStatus status);
 
     @Query(value = """
         SELECT 

--- a/src/main/java/com/example/warehouseManagement/Repositories/PickingJobRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/PickingJobRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import com.example.warehouseManagement.Domains.PickingJob;
+import com.example.warehouseManagement.Domains.PickingJob.PjStatus;
 
 public interface PickingJobRepository extends CrudRepository<PickingJob, Long> {
     @Query(value = "SELECT * FROM picking_job pj\n" + //
             "WHERE pj.status = 0 ORDER BY pj.date", nativeQuery = true)
-    public List<PickingJob> findAllPending();   
+    public List<PickingJob> findAllPending();
+
+    long countByStatus(PjStatus status);
 }

--- a/src/main/java/com/example/warehouseManagement/Repositories/PurchaseOrderRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/PurchaseOrderRepository.java
@@ -8,7 +8,11 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
 import com.example.warehouseManagement.Domains.PurchaseOrder;
+import com.example.warehouseManagement.Domains.DTOs.AgingPoDto;
+import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
+import com.example.warehouseManagement.Domains.DTOs.PoStatusBucketDto;
 import com.example.warehouseManagement.Domains.DTOs.PurchaseOrderDto;
+import com.example.warehouseManagement.Domains.DTOs.VendorSpendDto;
 
 
 public interface PurchaseOrderRepository extends CrudRepository<PurchaseOrder, Long>{
@@ -94,5 +98,75 @@ public interface PurchaseOrderRepository extends CrudRepository<PurchaseOrder, L
         po.date
     """, nativeQuery = true)
     public List<PurchaseOrderDto> findAllPendingPurchaseOrder();
-    
+
+    /**
+     * Dashboard KPI: count + value of open purchase orders
+     * (IN_TRANSIT = 0, PARTIALLY_RECEIVED = 2). RECEIVED (1) is closed.
+     */
+    @Query(value = """
+      SELECT
+        COUNT(DISTINCT po.id) AS "count",
+        COALESCE(ROUND(SUM(pol.qty * ic.cost), 2), 0) AS "totalValue"
+      FROM purchase_order po
+      LEFT JOIN purchase_order_line pol ON pol.purchase_order_id = po.id
+      LEFT JOIN item_cost ic ON ic.id = pol.item_cost_id
+      WHERE po.status IN (0, 2)
+      """, nativeQuery = true)
+    public OpenOrdersKpiDto findOpenPurchaseOrdersKpi();
+
+    /**
+     * Top 5 vendors by YTD spend (sum of qty * cost across all POs raised in
+     * the current calendar year).
+     */
+    @Query(value = """
+      SELECT
+        v.name AS "vendorName",
+        ROUND(SUM(pol.qty * ic.cost), 2) AS "total"
+      FROM purchase_order po
+      INNER JOIN purchase_order_line pol ON pol.purchase_order_id = po.id
+      INNER JOIN item_cost ic ON ic.id = pol.item_cost_id
+      INNER JOIN vendor v ON v.id = po.vendor_id
+      WHERE EXTRACT(YEAR FROM po.date) = EXTRACT(YEAR FROM CURRENT_DATE())
+      GROUP BY v.id, v.name
+      ORDER BY "total" DESC
+      LIMIT 5
+      """, nativeQuery = true)
+    public List<VendorSpendDto> findTopVendorsBySpendYtd();
+
+    /**
+     * PO count grouped by status — feeds the doughnut chart.
+     * 0 = IN_TRANSIT, 1 = RECEIVED, 2 = PARTIALLY_RECEIVED.
+     */
+    @Query(value = """
+      SELECT
+        po.status AS "status",
+        COUNT(*) AS "count"
+      FROM purchase_order po
+      GROUP BY po.status
+      ORDER BY po.status
+      """, nativeQuery = true)
+    public List<PoStatusBucketDto> findPoStatusBuckets();
+
+    /**
+     * POs older than 30 days that are still IN_TRANSIT (0) or PARTIALLY_RECEIVED (2).
+     * Sorted oldest-first so the worst offenders are at the top.
+     */
+    @Query(value = """
+      SELECT
+        po.id AS "id",
+        v.name AS "vendorName",
+        po.date AS "date",
+        DATEDIFF('DAY', po.date, CURRENT_DATE()) AS "ageDays",
+        po.status AS "status",
+        ROUND(SUM(pol.qty * ic.cost), 2) AS "total"
+      FROM purchase_order po
+      INNER JOIN purchase_order_line pol ON pol.purchase_order_id = po.id
+      INNER JOIN item_cost ic ON ic.id = pol.item_cost_id
+      INNER JOIN vendor v ON v.id = po.vendor_id
+      WHERE po.status IN (0, 2)
+        AND DATEDIFF('DAY', po.date, CURRENT_DATE()) > 30
+      GROUP BY po.id, v.name, po.date, po.status
+      ORDER BY "ageDays" DESC
+      """, nativeQuery = true)
+    public List<AgingPoDto> findAgingPurchaseOrders();
 }

--- a/src/main/java/com/example/warehouseManagement/Repositories/SalesOrderRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/SalesOrderRepository.java
@@ -8,7 +8,9 @@ import org.springframework.data.repository.query.Param;
 
 import com.example.warehouseManagement.Domains.Customer;
 import com.example.warehouseManagement.Domains.SalesOrder;
+import com.example.warehouseManagement.Domains.DTOs.DailySalesDto;
 import com.example.warehouseManagement.Domains.DTOs.MonthlySalesDto;
+import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
 import com.example.warehouseManagement.Domains.DTOs.PendingSalesOrderDto;
 import com.example.warehouseManagement.Domains.DTOs.SalesOrderDto;
 
@@ -186,6 +188,38 @@ public interface SalesOrderRepository extends CrudRepository<SalesOrder, Long>{
         so.date
       """, nativeQuery = true)
     public List<SalesOrderDto> findAllPendingSalesOrder();
+
+    /**
+     * Dashboard KPI: count + total value of sales orders not yet fully shipped
+     * (PENDING = 0, PARTIALLY_SHIPPED = 1).
+     */
+    @Query(value = """
+      SELECT
+        COUNT(DISTINCT so.id) AS "count",
+        COALESCE(ROUND(SUM(sol.qty * ip.price), 2), 0) AS "totalValue"
+      FROM sales_order so
+      LEFT JOIN sales_order_line sol ON sol.sales_order_id = so.id
+      LEFT JOIN item_price ip ON ip.id = sol.item_price_id
+      WHERE so.status IN (0, 1)
+      """, nativeQuery = true)
+    public OpenOrdersKpiDto findOpenSalesOrdersKpi();
+
+    /**
+     * Dashboard daily-sales trend for the last 30 days. One row per date that
+     * had at least one sales order. Used by the Chart.js line chart.
+     */
+    @Query(value = """
+      SELECT
+        so.date AS "day",
+        COALESCE(ROUND(SUM(sol.qty * ip.price), 2), 0) AS "total"
+      FROM sales_order so
+      INNER JOIN sales_order_line sol ON sol.sales_order_id = so.id
+      INNER JOIN item_price ip ON ip.id = sol.item_price_id
+      WHERE so.date >= DATEADD('DAY', -30, CURRENT_DATE())
+      GROUP BY so.date
+      ORDER BY so.date
+      """, nativeQuery = true)
+    public List<DailySalesDto> findDailySalesLast30Days();
 }
 
 /*

--- a/src/main/java/com/example/warehouseManagement/Repositories/StockRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/StockRepository.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.warehouseManagement.Domains.Item;
 import com.example.warehouseManagement.Domains.Stock;
+import com.example.warehouseManagement.Domains.DTOs.InventorySnapshotDto;
+import com.example.warehouseManagement.Domains.DTOs.ReorderItemDto;
 import com.example.warehouseManagement.Domains.DTOs.StockLevelReportItemDto;
 import com.example.warehouseManagement.Domains.DTOs.TopFiveMoversDto;
 
@@ -526,11 +528,87 @@ public interface StockRepository extends CrudRepository<Stock, Long> {
    * WHERE item.vendor_id = 1
    * GROUP BY item.id
    * 
-   * 
-   * 
-   * 
-   * 
+   *
+   *
+   *
+   *
    */
+
+  /**
+   * Dashboard inventory snapshot: total value (stock × current cost), total
+   * units on hand, count of SKUs that are completely out of stock, and count of
+   * SKUs with weeks-of-inventory &lt; 2 (low-stock threshold).
+   * <p>
+   * Velocity logic mirrors {@link #getTopFiveMovers()} (SUM(sol.qty) /
+   * EXTRACT(WEEK FROM CURRENT_DATE())).
+   */
+  @Query(value = """
+      SELECT
+        COALESCE(ROUND(SUM(s.qty_on_hand * ic.cost), 2), 0) AS "totalValue",
+        COALESCE(SUM(s.qty_on_hand), 0) AS "totalUnits",
+        (
+          SELECT COUNT(*) FROM item i
+          WHERE NOT EXISTS (
+            SELECT 1 FROM stock s2 WHERE s2.item_id = i.id AND s2.qty_on_hand > 0
+          )
+        ) AS "oosCount",
+        (
+          SELECT COUNT(*) FROM (
+            SELECT
+              item.id,
+              NVL((SELECT SUM(s3.qty_on_hand) FROM stock s3 WHERE s3.item_id = item.id), 0) AS qoh,
+              NVL(SUM(sol.qty) / NULLIF(EXTRACT(WEEK FROM CURRENT_DATE()), 0), 0) AS velocity
+            FROM item
+            LEFT JOIN sales_order_line sol ON sol.item_id = item.id
+            GROUP BY item.id
+          ) v
+          WHERE v.velocity > 0
+            AND v.qoh / NULLIF(v.velocity, 0) < 2
+        ) AS "lowStockCount"
+      FROM stock s
+      LEFT JOIN item_cost ic ON ic.item_id = s.item_id
+        AND ic.start_date <= CURRENT_DATE()
+        AND ic.end_date >= CURRENT_DATE()
+      """, nativeQuery = true)
+  public InventorySnapshotDto findInventorySnapshot();
+
+  /**
+   * Items the buyer should reorder: items with non-zero weekly velocity, less
+   * than 2 weeks of inventory on hand, and no PO currently in transit.
+   * Top 10 by lowest weeks-of-inventory.
+   */
+  @Query(value = """
+      SELECT
+        item.id AS "itemId",
+        item.sku AS "sku",
+        item.description AS "description",
+        v.name AS "vendorName",
+        NVL((SELECT SUM(s.qty_on_hand) FROM stock s WHERE s.item_id = item.id), 0) AS "qtyOnHand",
+        CAST(NVL(SUM(sol.qty) / NULLIF(EXTRACT(WEEK FROM CURRENT_DATE()), 0), 0) AS INTEGER) AS "weeklyVelocity",
+        NVL(
+          ROUND(
+            NVL((SELECT SUM(s.qty_on_hand) FROM stock s WHERE s.item_id = item.id), 0) /
+            NULLIF(CAST(SUM(sol.qty) / NULLIF(EXTRACT(WEEK FROM CURRENT_DATE()), 0) AS REAL), 0),
+            2
+          ),
+          0
+        ) AS "weeksOfInventory"
+      FROM item
+      INNER JOIN vendor v ON v.id = item.vendor_id
+      INNER JOIN sales_order_line sol ON sol.item_id = item.id
+      WHERE NOT EXISTS (
+        SELECT 1 FROM purchase_order_line pol
+        INNER JOIN purchase_order po ON po.id = pol.purchase_order_id
+        WHERE pol.item_id = item.id AND po.status IN (0, 2)
+      )
+      GROUP BY item.id, item.sku, item.description, v.name
+      HAVING SUM(sol.qty) / NULLIF(EXTRACT(WEEK FROM CURRENT_DATE()), 0) > 0
+         AND NVL((SELECT SUM(s.qty_on_hand) FROM stock s WHERE s.item_id = item.id), 0)
+             / NULLIF(CAST(SUM(sol.qty) / NULLIF(EXTRACT(WEEK FROM CURRENT_DATE()), 0) AS REAL), 0) < 2
+      ORDER BY "weeksOfInventory" ASC
+      LIMIT 10
+      """, nativeQuery = true)
+  public List<ReorderItemDto> findReorderCandidates();
 
 }
 

--- a/src/main/java/com/example/warehouseManagement/Repositories/UserRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/UserRepository.java
@@ -1,0 +1,19 @@
+package com.example.warehouseManagement.Repositories;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.example.warehouseManagement.Domains.User;
+
+public interface UserRepository extends CrudRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByPasswordResetToken(String token);
+
+    boolean existsByUsername(String username);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/example/warehouseManagement/Security/SecurityConfig.java
+++ b/src/main/java/com/example/warehouseManagement/Security/SecurityConfig.java
@@ -1,0 +1,80 @@
+package com.example.warehouseManagement.Security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityContextRepository securityContextRepository() {
+        return new HttpSessionSecurityContextRepository();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   TwoFactorAuthenticationSuccessHandler successHandler) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                        "/login",
+                        "/verify-2fa",
+                        "/forgot-password",
+                        "/reset-password",
+                        "/css/**",
+                        "/js/**",
+                        "/images/**",
+                        "/webjars/**",
+                        "/h2-console/**"
+                ).permitAll()
+                .requestMatchers("/admin/**").hasRole("ADMIN")
+                .anyRequest().authenticated()
+            )
+            .formLogin(form -> form
+                .loginPage("/login")
+                .loginProcessingUrl("/login")
+                .usernameParameter("username")
+                .passwordParameter("password")
+                .successHandler(successHandler)
+                .failureUrl("/login?error")
+                .permitAll()
+            )
+            .logout(logout -> logout
+                .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
+                .logoutSuccessUrl("/login?logout")
+                .invalidateHttpSession(true)
+                .deleteCookies("JSESSIONID")
+                .permitAll()
+            )
+            // H2 console renders inside a frame; keep frame-options off for the console only.
+            .headers(headers -> headers
+                .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
+            )
+            // The H2 console posts forms without CSRF tokens.
+            .csrf(csrf -> csrf.ignoringRequestMatchers(new AntPathRequestMatcher("/h2-console/**")))
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                .sessionFixation(s -> s.migrateSession())
+            );
+
+        // Disable default httpBasic to keep login form-only
+        http.httpBasic(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Security/TwoFactorAuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/warehouseManagement/Security/TwoFactorAuthenticationSuccessHandler.java
@@ -1,0 +1,79 @@
+package com.example.warehouseManagement.Security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.stereotype.Component;
+
+import com.example.warehouseManagement.Domains.User;
+import com.example.warehouseManagement.Services.EmailService;
+import com.example.warehouseManagement.Services.UserService;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * Runs after Spring Security validates the username/password.
+ * <p>
+ * If the user has two-factor enabled we clear the security context, stash the
+ * username on the HttpSession under {@link #PENDING_2FA_USERNAME}, generate +
+ * email a code, and redirect to {@code /verify-2fa}. The controller for that
+ * endpoint will promote the session to a full {@link Authentication} once the
+ * code is verified.
+ */
+@Component
+public class TwoFactorAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    public static final String PENDING_2FA_USERNAME = "PENDING_2FA_USERNAME";
+
+    private final UserService userService;
+    private final EmailService emailService;
+    private final SecurityContextRepository securityContextRepository;
+
+    public TwoFactorAuthenticationSuccessHandler(UserService userService,
+                                                 EmailService emailService,
+                                                 SecurityContextRepository securityContextRepository) {
+        this.userService = userService;
+        this.emailService = emailService;
+        this.securityContextRepository = securityContextRepository;
+        setDefaultTargetUrl("/");
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        String username = authentication.getName();
+        User user = userService.findByUsername(username).orElse(null);
+        if (user == null) {
+            // Should not happen — auth just succeeded — but fail closed.
+            SecurityContextHolder.clearContext();
+            response.sendRedirect("/login?error");
+            return;
+        }
+
+        if (user.isTwoFactorEnabled()) {
+            String code = userService.generateTwoFactorCode(user);
+            emailService.sendTwoFactorCode(user.getEmail(), code);
+
+            // Demote the authenticated session: the UsernamePasswordAuthenticationFilter
+            // has already persisted the authenticated SecurityContext to the session.
+            // Overwrite it with an empty context so the user cannot reach protected pages
+            // by skipping /verify-2fa.
+            SecurityContextHolder.clearContext();
+            securityContextRepository.saveContext(SecurityContextHolder.createEmptyContext(), request, response);
+            HttpSession session = request.getSession(true);
+            session.setAttribute(PENDING_2FA_USERNAME, username);
+            response.sendRedirect("/verify-2fa");
+            return;
+        }
+
+        userService.recordSuccessfulLogin(user);
+        super.onAuthenticationSuccess(request, response, authentication);
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Services/BackorderService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/BackorderService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.example.warehouseManagement.Domains.Backorder;
 import com.example.warehouseManagement.Domains.SalesOrder;
 import com.example.warehouseManagement.Domains.DTOs.BackorderDto;
+import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
 
 public interface BackorderService {
     public Iterable<Backorder> findAll();
@@ -12,4 +13,7 @@ public interface BackorderService {
     public Backorder save(Backorder backorder);
     public void delete(Backorder backorder);
     public List<BackorderDto> findBackordersByYear(int year);
+
+    /** Dashboard KPI: count + total value of active backorders. */
+    OpenOrdersKpiDto findBackorderKpi();
 }

--- a/src/main/java/com/example/warehouseManagement/Services/BackorderServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/BackorderServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.example.warehouseManagement.Domains.Backorder;
 import com.example.warehouseManagement.Domains.SalesOrder;
 import com.example.warehouseManagement.Domains.DTOs.BackorderDto;
+import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
 import com.example.warehouseManagement.Repositories.BackorderRepository;
 
 @Service
@@ -41,5 +42,10 @@ public class BackorderServiceImpl implements BackorderService {
     public List<BackorderDto> findBackordersByYear(int year) {
         return backorderRepository.findBackordersByYear(year);
     }
-    
+
+    @Override
+    public OpenOrdersKpiDto findBackorderKpi() {
+        return backorderRepository.findBackorderKpi();
+    }
+
 }

--- a/src/main/java/com/example/warehouseManagement/Services/EmailService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/EmailService.java
@@ -1,0 +1,7 @@
+package com.example.warehouseManagement.Services;
+
+public interface EmailService {
+    void sendTwoFactorCode(String to, String code);
+
+    void sendPasswordResetLink(String to, String resetUrl);
+}

--- a/src/main/java/com/example/warehouseManagement/Services/EmailServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/EmailServiceImpl.java
@@ -1,0 +1,60 @@
+package com.example.warehouseManagement.Services;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailServiceImpl implements EmailService {
+
+    private static final Logger log = LoggerFactory.getLogger(EmailServiceImpl.class);
+
+    private final JavaMailSender mailSender;
+    private final String fromAddress;
+
+    public EmailServiceImpl(JavaMailSender mailSender,
+                            @Value("${app.mail.from}") String fromAddress) {
+        this.mailSender = mailSender;
+        this.fromAddress = fromAddress;
+    }
+
+    @Override
+    public void sendTwoFactorCode(String to, String code) {
+        String subject = "Your verification code";
+        String body = "Your verification code is: " + code
+                + "\n\nThis code will expire shortly. If you did not try to sign in, ignore this email.";
+        send(to, subject, body);
+    }
+
+    @Override
+    public void sendPasswordResetLink(String to, String resetUrl) {
+        String subject = "Reset your password";
+        String body = "We received a request to reset your password.\n"
+                + "Click the link below to choose a new one:\n\n"
+                + resetUrl
+                + "\n\nIf you did not request this, you can ignore this email.";
+        send(to, subject, body);
+    }
+
+    private void send(String to, String subject, String body) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromAddress);
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(body);
+        try {
+            mailSender.send(message);
+            log.info("Email sent to {} subject=\"{}\"", to, subject);
+        } catch (MailException e) {
+            // Dev fallback: log the full message so the developer can grab the code/link
+            // without having SMTP configured. In production set up SMTP via env vars.
+            log.warn("Failed to send email via SMTP ({}). Falling back to console output.", e.getMessage());
+            log.info("---- EMAIL (dev fallback) ----\nTo: {}\nSubject: {}\n\n{}\n------------------------------",
+                    to, subject, body);
+        }
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Services/GoodsReceiptNoteImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/GoodsReceiptNoteImpl.java
@@ -164,5 +164,10 @@ public class GoodsReceiptNoteImpl implements GoodsReceiptNoteService {
         }
         return goodsReceiptNoteDto;
     }
-    
+
+    @Override
+    public long countPending() {
+        return goodsReceiptNoteRepository.countByStatus(GrnStatus.PENDING);
+    }
+
 }

--- a/src/main/java/com/example/warehouseManagement/Services/GoodsReceiptNoteService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/GoodsReceiptNoteService.java
@@ -52,5 +52,8 @@ public interface GoodsReceiptNoteService {
     public GoodsReceiptNote create(PurchaseOrder purchaseOrder);
 
     public GoodsReceiptNoteDto addGoodReceiptNoteLines(GoodsReceiptNote goodsReceiptNote);
+
+    /** Dashboard KPI: count of pending GRNs. */
+    long countPending();
 }
 

--- a/src/main/java/com/example/warehouseManagement/Services/PickingJobService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PickingJobService.java
@@ -13,4 +13,7 @@ public interface PickingJobService {
     public PickingJob save(PickingJob pickingJob);
     public void delete(PickingJob pickingJob);
     public PickingJob fulfill(PickingJob pickingJob, PickingJobDto pickingJobDto);
+
+    /** Dashboard KPI: count of pending picking jobs. */
+    long countPending();
 }

--- a/src/main/java/com/example/warehouseManagement/Services/PickingJobServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PickingJobServiceImpl.java
@@ -142,4 +142,9 @@ public class PickingJobServiceImpl implements PickingJobService {
         return pickingJobRepository.save(pickingJob);
     }
 
+    @Override
+    public long countPending() {
+        return pickingJobRepository.countByStatus(PjStatus.PENDING);
+    }
+
 }

--- a/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderService.java
@@ -4,7 +4,11 @@ import java.util.List;
 import java.util.Optional;
 
 import com.example.warehouseManagement.Domains.PurchaseOrder;
+import com.example.warehouseManagement.Domains.DTOs.AgingPoDto;
+import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
+import com.example.warehouseManagement.Domains.DTOs.PoStatusBucketDto;
 import com.example.warehouseManagement.Domains.DTOs.PurchaseOrderDto;
+import com.example.warehouseManagement.Domains.DTOs.VendorSpendDto;
 import com.example.warehouseManagement.Domains.Exceptions.PurchaseOrderNotFoundException;
 import com.example.warehouseManagement.Domains.Exceptions.ReceivedOrderModificationException;
 
@@ -60,5 +64,17 @@ public interface PurchaseOrderService {
      * @return
      */
     public List<PurchaseOrderDto> findAllPendingPurchaseOrder();
+
+    /** Dashboard KPI: count + value of open purchase orders. */
+    OpenOrdersKpiDto findOpenPurchaseOrdersKpi();
+
+    /** Top 5 vendors by year-to-date spend, used by the dashboard bar chart. */
+    List<VendorSpendDto> findTopVendorsBySpendYtd();
+
+    /** PO count grouped by status (0/1/2) — feeds the dashboard doughnut. */
+    List<PoStatusBucketDto> findPoStatusBuckets();
+
+    /** Open POs older than 30 days, oldest first — feeds the aging table. */
+    List<AgingPoDto> findAgingPurchaseOrders();
 
 }

--- a/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderServiceImpl.java
@@ -12,7 +12,11 @@ import com.example.warehouseManagement.Domains.Item;
 import com.example.warehouseManagement.Domains.PurchaseOrder;
 import com.example.warehouseManagement.Domains.PurchaseOrder.PoStatus;
 import com.example.warehouseManagement.Domains.PurchaseOrderLine;
+import com.example.warehouseManagement.Domains.DTOs.AgingPoDto;
+import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
+import com.example.warehouseManagement.Domains.DTOs.PoStatusBucketDto;
 import com.example.warehouseManagement.Domains.DTOs.PurchaseOrderDto;
+import com.example.warehouseManagement.Domains.DTOs.VendorSpendDto;
 import com.example.warehouseManagement.Domains.Exceptions.PurchaseOrderNotFoundException;
 import com.example.warehouseManagement.Domains.Exceptions.ReceivedOrderModificationException;
 import com.example.warehouseManagement.Repositories.GoodsReceiptNoteLineRepository;
@@ -169,6 +173,26 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
     @Override
     public List<PurchaseOrderDto> findAllPendingPurchaseOrder() {
         return purchaseOrderRepository.findAllPendingPurchaseOrder();
+    }
+
+    @Override
+    public OpenOrdersKpiDto findOpenPurchaseOrdersKpi() {
+        return purchaseOrderRepository.findOpenPurchaseOrdersKpi();
+    }
+
+    @Override
+    public List<VendorSpendDto> findTopVendorsBySpendYtd() {
+        return purchaseOrderRepository.findTopVendorsBySpendYtd();
+    }
+
+    @Override
+    public List<PoStatusBucketDto> findPoStatusBuckets() {
+        return purchaseOrderRepository.findPoStatusBuckets();
+    }
+
+    @Override
+    public List<AgingPoDto> findAgingPurchaseOrders() {
+        return purchaseOrderRepository.findAgingPurchaseOrders();
     }
 
 }

--- a/src/main/java/com/example/warehouseManagement/Services/SalesOrderService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/SalesOrderService.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import com.example.warehouseManagement.Domains.Customer;
 import com.example.warehouseManagement.Domains.LastThreeMonthsSales;
 import com.example.warehouseManagement.Domains.SalesOrder;
+import com.example.warehouseManagement.Domains.DTOs.DailySalesDto;
+import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
 import com.example.warehouseManagement.Domains.DTOs.PendingSalesOrderDto;
 import com.example.warehouseManagement.Domains.DTOs.SalesOrderDto;
 import com.example.warehouseManagement.Domains.Exceptions.SalesOrderNotFoundException;
@@ -81,6 +83,12 @@ public interface SalesOrderService {
      * @return
      */
     public LastThreeMonthsSales findLastThreeMonthsSales();
+
+    /** Dashboard KPI: count + value of sales orders not yet fully shipped. */
+    OpenOrdersKpiDto findOpenSalesOrdersKpi();
+
+    /** Dashboard line chart: daily sales totals for the last 30 days. */
+    List<DailySalesDto> findDailySalesLast30Days();
 }
 
 

--- a/src/main/java/com/example/warehouseManagement/Services/SalesOrderServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/SalesOrderServiceImpl.java
@@ -13,6 +13,8 @@ import com.example.warehouseManagement.Domains.PickingJobLine;
 import com.example.warehouseManagement.Domains.SalesOrder;
 import com.example.warehouseManagement.Domains.SalesOrder.SoStatus;
 import com.example.warehouseManagement.Domains.SalesOrderLine;
+import com.example.warehouseManagement.Domains.DTOs.DailySalesDto;
+import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
 import com.example.warehouseManagement.Domains.DTOs.PendingSalesOrderDto;
 import com.example.warehouseManagement.Domains.DTOs.SalesOrderDto;
 import com.example.warehouseManagement.Domains.Exceptions.SalesOrderNotFoundException;
@@ -180,6 +182,16 @@ public class SalesOrderServiceImpl implements SalesOrderService {
     @Override
     public List<SalesOrderDto> findAllPendingOrders() {
         return salesOrderRepository.findAllPendingSalesOrder();
+    }
+
+    @Override
+    public OpenOrdersKpiDto findOpenSalesOrdersKpi() {
+        return salesOrderRepository.findOpenSalesOrdersKpi();
+    }
+
+    @Override
+    public List<DailySalesDto> findDailySalesLast30Days() {
+        return salesOrderRepository.findDailySalesLast30Days();
     }
 
 }

--- a/src/main/java/com/example/warehouseManagement/Services/StockService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/StockService.java
@@ -6,8 +6,10 @@ import java.util.Optional;
 import com.example.warehouseManagement.Domains.PickingJob;
 import com.example.warehouseManagement.Domains.Stock;
 import com.example.warehouseManagement.Domains.WarehouseSection;
+import com.example.warehouseManagement.Domains.DTOs.InventorySnapshotDto;
 import com.example.warehouseManagement.Domains.DTOs.PutAwayTaskDto;
 import com.example.warehouseManagement.Domains.DTOs.PutAwayTasksDtoWrapper;
+import com.example.warehouseManagement.Domains.DTOs.ReorderItemDto;
 import com.example.warehouseManagement.Domains.DTOs.StockLevelReportItemDto;
 import com.example.warehouseManagement.Domains.DTOs.TopFiveMoversDto;
 
@@ -38,4 +40,13 @@ public interface StockService {
     public Stock save(Stock stock);
 
     public void putAwayStocks(PutAwayTasksDtoWrapper wrapper, List<Stock> stocks);
+
+    /** Dashboard inventory snapshot: value, units, OOS count, low-stock count. */
+    InventorySnapshotDto findInventorySnapshot();
+
+    /** Items the buyer should reorder (low WoI, no PO in transit). */
+    List<ReorderItemDto> findReorderCandidates();
+
+    /** Count of stock rows currently sitting on the floor awaiting put-away. */
+    long countStockOnFloor();
 }

--- a/src/main/java/com/example/warehouseManagement/Services/StockServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/StockServiceImpl.java
@@ -10,8 +10,10 @@ import com.example.warehouseManagement.Domains.PickingJob;
 import com.example.warehouseManagement.Domains.PickingJobLine;
 import com.example.warehouseManagement.Domains.Stock;
 import com.example.warehouseManagement.Domains.WarehouseSection;
+import com.example.warehouseManagement.Domains.DTOs.InventorySnapshotDto;
 import com.example.warehouseManagement.Domains.DTOs.PutAwayTaskDto;
 import com.example.warehouseManagement.Domains.DTOs.PutAwayTasksDtoWrapper;
+import com.example.warehouseManagement.Domains.DTOs.ReorderItemDto;
 import com.example.warehouseManagement.Domains.DTOs.StockLevelReportItemDto;
 import com.example.warehouseManagement.Domains.DTOs.TopFiveMoversDto;
 import com.example.warehouseManagement.Repositories.StockRepository;
@@ -124,6 +126,21 @@ public class StockServiceImpl implements StockService {
     @Override
     public List<Stock> findStocksByWareHouseSectionNumber(String warehouseSectionNumber) {
        return stockRepository.findStocksByWarehouseSectionNumber(warehouseSectionNumber);
+    }
+
+    @Override
+    public InventorySnapshotDto findInventorySnapshot() {
+        return stockRepository.findInventorySnapshot();
+    }
+
+    @Override
+    public List<ReorderItemDto> findReorderCandidates() {
+        return stockRepository.findReorderCandidates();
+    }
+
+    @Override
+    public long countStockOnFloor() {
+        return stockRepository.findStockOnFloor().size();
     }
 
 }

--- a/src/main/java/com/example/warehouseManagement/Services/UserService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/UserService.java
@@ -1,0 +1,43 @@
+package com.example.warehouseManagement.Services;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import com.example.warehouseManagement.Domains.User;
+import com.example.warehouseManagement.Domains.DTOs.UserFormDto;
+
+public interface UserService extends UserDetailsService {
+
+    List<User> findAll();
+
+    Optional<User> findById(Long id);
+
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByEmail(String email);
+
+    User create(UserFormDto dto);
+
+    User update(Long id, UserFormDto dto);
+
+    void delete(Long id);
+
+    /** Generates a fresh 6-digit 2FA code, persists it with expiry, and returns it. */
+    String generateTwoFactorCode(User user);
+
+    /** Returns true if the code is valid and not expired. Always clears the code after a check. */
+    boolean verifyTwoFactorCode(User user, String code);
+
+    /** Generates a fresh password reset token (URL-safe), persists it with expiry, and returns it. */
+    String generatePasswordResetToken(User user);
+
+    /** Looks up a user by reset token; returns empty if not found or expired. */
+    Optional<User> findByValidResetToken(String token);
+
+    /** Sets a new password (BCrypt-hashed) and invalidates the reset token. */
+    void resetPassword(User user, String rawPassword);
+
+    void recordSuccessfulLogin(User user);
+}

--- a/src/main/java/com/example/warehouseManagement/Services/UserServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/UserServiceImpl.java
@@ -1,0 +1,191 @@
+package com.example.warehouseManagement.Services;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User.UserBuilder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.example.warehouseManagement.Domains.User;
+import com.example.warehouseManagement.Domains.DTOs.UserFormDto;
+import com.example.warehouseManagement.Domains.Exceptions.DuplicateUserException;
+import com.example.warehouseManagement.Domains.Exceptions.UserNotFoundException;
+import com.example.warehouseManagement.Repositories.UserRepository;
+
+@Service
+public class UserServiceImpl implements UserService {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final int twoFactorTtlMinutes;
+    private final int resetTokenTtlMinutes;
+
+    public UserServiceImpl(UserRepository userRepository,
+                           PasswordEncoder passwordEncoder,
+                           @Value("${app.auth.two-factor-code-ttl-minutes}") int twoFactorTtlMinutes,
+                           @Value("${app.auth.password-reset-token-ttl-minutes}") int resetTokenTtlMinutes) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.twoFactorTtlMinutes = twoFactorTtlMinutes;
+        this.resetTokenTtlMinutes = resetTokenTtlMinutes;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+        UserBuilder builder = org.springframework.security.core.userdetails.User.builder()
+                .username(user.getUsername())
+                .password(user.getPassword())
+                .authorities(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
+                .disabled(!user.isEnabled());
+        return builder.build();
+    }
+
+    @Override
+    public List<User> findAll() {
+        List<User> all = new ArrayList<>();
+        userRepository.findAll().forEach(all::add);
+        return all;
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return userRepository.findById(id);
+    }
+
+    @Override
+    public Optional<User> findByUsername(String username) {
+        return userRepository.findByUsername(username);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userRepository.findByEmail(email == null ? null : email.trim().toLowerCase());
+    }
+
+    @Override
+    public User create(UserFormDto dto) {
+        if (userRepository.existsByUsername(dto.getUsername())) {
+            throw new DuplicateUserException("Username already in use");
+        }
+        if (userRepository.existsByEmail(dto.getEmail())) {
+            throw new DuplicateUserException("Email already in use");
+        }
+        if (dto.getPassword() == null || dto.getPassword().isBlank()) {
+            throw new IllegalArgumentException("Password is required");
+        }
+        User user = User.builder()
+                .username(dto.getUsername().trim())
+                .email(dto.getEmail().trim().toLowerCase())
+                .password(passwordEncoder.encode(dto.getPassword()))
+                .role(dto.getRole())
+                .enabled(dto.isEnabled())
+                .twoFactorEnabled(dto.isTwoFactorEnabled())
+                .createdAt(Instant.now())
+                .build();
+        return userRepository.save(user);
+    }
+
+    @Override
+    public User update(Long id, UserFormDto dto) {
+        User existing = userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundException("User " + id + " not found"));
+
+        String newUsername = dto.getUsername().trim();
+        String newEmail = dto.getEmail().trim().toLowerCase();
+
+        if (!existing.getUsername().equals(newUsername) && userRepository.existsByUsername(newUsername)) {
+            throw new DuplicateUserException("Username already in use");
+        }
+        if (!existing.getEmail().equals(newEmail) && userRepository.existsByEmail(newEmail)) {
+            throw new DuplicateUserException("Email already in use");
+        }
+
+        existing.setUsername(newUsername);
+        existing.setEmail(newEmail);
+        existing.setRole(dto.getRole());
+        existing.setEnabled(dto.isEnabled());
+        existing.setTwoFactorEnabled(dto.isTwoFactorEnabled());
+        if (dto.getPassword() != null && !dto.getPassword().isBlank()) {
+            existing.setPassword(passwordEncoder.encode(dto.getPassword()));
+        }
+        return userRepository.save(existing);
+    }
+
+    @Override
+    public void delete(Long id) {
+        if (!userRepository.existsById(id)) {
+            throw new UserNotFoundException("User " + id + " not found");
+        }
+        userRepository.deleteById(id);
+    }
+
+    @Override
+    public String generateTwoFactorCode(User user) {
+        String code = String.format("%06d", RANDOM.nextInt(1_000_000));
+        user.setTwoFactorCode(passwordEncoder.encode(code));
+        user.setTwoFactorCodeExpiresAt(Instant.now().plus(twoFactorTtlMinutes, ChronoUnit.MINUTES));
+        userRepository.save(user);
+        return code;
+    }
+
+    @Override
+    public boolean verifyTwoFactorCode(User user, String code) {
+        String stored = user.getTwoFactorCode();
+        Instant expiry = user.getTwoFactorCodeExpiresAt();
+        boolean valid = stored != null
+                && expiry != null
+                && expiry.isAfter(Instant.now())
+                && passwordEncoder.matches(code, stored);
+        // Single-use: always clear after a check
+        user.setTwoFactorCode(null);
+        user.setTwoFactorCodeExpiresAt(null);
+        userRepository.save(user);
+        return valid;
+    }
+
+    @Override
+    public String generatePasswordResetToken(User user) {
+        byte[] bytes = new byte[32];
+        RANDOM.nextBytes(bytes);
+        String token = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        user.setPasswordResetToken(token);
+        user.setPasswordResetTokenExpiresAt(Instant.now().plus(resetTokenTtlMinutes, ChronoUnit.MINUTES));
+        userRepository.save(user);
+        return token;
+    }
+
+    @Override
+    public Optional<User> findByValidResetToken(String token) {
+        return userRepository.findByPasswordResetToken(token)
+                .filter(u -> u.getPasswordResetTokenExpiresAt() != null
+                        && u.getPasswordResetTokenExpiresAt().isAfter(Instant.now()));
+    }
+
+    @Override
+    public void resetPassword(User user, String rawPassword) {
+        user.setPassword(passwordEncoder.encode(rawPassword));
+        user.setPasswordResetToken(null);
+        user.setPasswordResetTokenExpiresAt(null);
+        userRepository.save(user);
+    }
+
+    @Override
+    public void recordSuccessfulLogin(User user) {
+        user.setLastLoginAt(Instant.now());
+        userRepository.save(user);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,23 @@ spring.jpa.properties.hibernate.format_sql=true
 
 spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+# ----- Mail -----
+# Configure real SMTP via environment variables in production.
+# Without these, EmailService falls back to logging the message body to the console (DEV ONLY).
+spring.mail.host=${MAIL_HOST:smtp.example.com}
+spring.mail.port=${MAIL_PORT:587}
+spring.mail.username=${MAIL_USERNAME:}
+spring.mail.password=${MAIL_PASSWORD:}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.test-connection=false
+
+# ----- App auth settings -----
+app.mail.from=${MAIL_FROM:no-reply@warehouse.local}
+app.auth.two-factor-code-ttl-minutes=10
+app.auth.password-reset-token-ttl-minutes=30
+app.auth.base-url=${APP_BASE_URL:http://localhost:8080}
+
+# Allow framing so the H2 console works alongside Spring Security
+spring.h2.console.settings.web-allow-others=false

--- a/src/main/resources/templates/admin/newUserForm.html
+++ b/src/main/resources/templates/admin/newUserForm.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<div th:insert="~{fragments/header :: header}"></div>
+<div th:insert="~{fragments/navbar :: navbar}"></div>
+
+<div class="container">
+    <div class="col-md-6 mx-auto">
+        <h1 class="my-3">New user</h1>
+
+        <div th:if="${#fields.hasGlobalErrors()}" class="alert alert-danger">
+            <p th:each="err : ${#fields.globalErrors()}" th:text="${err}"></p>
+        </div>
+
+        <form th:action="@{/admin/users/new}" th:object="${userForm}" method="post" class="row g-3 needs-validation" novalidate>
+            <div class="col-md-12">
+                <label for="username" class="form-label">Username</label>
+                <input class="form-control" th:field="*{username}" type="text" id="username" required>
+                <div class="text-danger small" th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></div>
+            </div>
+            <div class="col-md-12">
+                <label for="email" class="form-label">Email</label>
+                <input class="form-control" th:field="*{email}" type="email" id="email" required>
+                <div class="text-danger small" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></div>
+            </div>
+            <div class="col-md-12">
+                <label for="password" class="form-label">Password</label>
+                <input class="form-control" th:field="*{password}" type="password" id="password" minlength="8" required>
+                <div class="text-danger small" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></div>
+                <div class="form-text">At least 8 characters.</div>
+            </div>
+            <div class="col-md-6">
+                <label for="role" class="form-label">Role</label>
+                <select class="form-select" th:field="*{role}" id="role">
+                    <option th:each="r : ${roles}" th:value="${r}" th:text="${r}"></option>
+                </select>
+            </div>
+            <div class="col-md-3 form-check pt-4">
+                <input class="form-check-input" th:field="*{enabled}" type="checkbox" id="enabled">
+                <label class="form-check-label" for="enabled">Enabled</label>
+            </div>
+            <div class="col-md-3 form-check pt-4">
+                <input class="form-check-input" th:field="*{twoFactorEnabled}" type="checkbox" id="twoFactorEnabled">
+                <label class="form-check-label" for="twoFactorEnabled">2FA</label>
+            </div>
+            <div class="col-12 d-grid">
+                <button type="submit" class="btn btn-dark">Create user</button>
+            </div>
+            <div class="col-12">
+                <a href="/admin/users" class="btn btn-link">Back</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div th:insert="~{fragments/footer :: footer}"></div>
+</html>

--- a/src/main/resources/templates/admin/updateUserForm.html
+++ b/src/main/resources/templates/admin/updateUserForm.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<div th:insert="~{fragments/header :: header}"></div>
+<div th:insert="~{fragments/navbar :: navbar}"></div>
+
+<div class="container">
+    <div class="col-md-6 mx-auto">
+        <h1 class="my-3">Edit user</h1>
+
+        <div th:if="${#fields.hasGlobalErrors()}" class="alert alert-danger">
+            <p th:each="err : ${#fields.globalErrors()}" th:text="${err}"></p>
+        </div>
+
+        <form th:action="@{'/admin/users/' + ${userForm.id} + '/update'}" th:object="${userForm}" method="post" class="row g-3 needs-validation" novalidate>
+            <div class="col-md-12">
+                <label for="username" class="form-label">Username</label>
+                <input class="form-control" th:field="*{username}" type="text" id="username" required>
+                <div class="text-danger small" th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></div>
+            </div>
+            <div class="col-md-12">
+                <label for="email" class="form-label">Email</label>
+                <input class="form-control" th:field="*{email}" type="email" id="email" required>
+                <div class="text-danger small" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></div>
+            </div>
+            <div class="col-md-12">
+                <label for="password" class="form-label">New password</label>
+                <input class="form-control" th:field="*{password}" type="password" id="password" minlength="8">
+                <div class="form-text">Leave blank to keep current password.</div>
+                <div class="text-danger small" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></div>
+            </div>
+            <div class="col-md-6">
+                <label for="role" class="form-label">Role</label>
+                <select class="form-select" th:field="*{role}" id="role">
+                    <option th:each="r : ${roles}" th:value="${r}" th:text="${r}"></option>
+                </select>
+            </div>
+            <div class="col-md-3 form-check pt-4">
+                <input class="form-check-input" th:field="*{enabled}" type="checkbox" id="enabled">
+                <label class="form-check-label" for="enabled">Enabled</label>
+            </div>
+            <div class="col-md-3 form-check pt-4">
+                <input class="form-check-input" th:field="*{twoFactorEnabled}" type="checkbox" id="twoFactorEnabled">
+                <label class="form-check-label" for="twoFactorEnabled">2FA</label>
+            </div>
+            <div class="col-12 d-grid">
+                <button type="submit" class="btn btn-dark">Save</button>
+            </div>
+            <div class="col-12">
+                <a th:href="@{'/admin/users/' + ${userForm.id}}" class="btn btn-link">Back</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div th:insert="~{fragments/footer :: footer}"></div>
+</html>

--- a/src/main/resources/templates/admin/userDetails.html
+++ b/src/main/resources/templates/admin/userDetails.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<div th:insert="~{fragments/header :: header}"></div>
+<div th:insert="~{fragments/navbar :: navbar}"></div>
+
+<div class="container">
+    <div th:if="${param.created}" class="alert alert-success alert-dismissible fade show my-3" role="alert">
+        User created
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <div th:if="${param.updated}" class="alert alert-success alert-dismissible fade show my-3" role="alert">
+        User updated
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <div th:if="${param.cannotDeleteSelf}" class="alert alert-warning alert-dismissible fade show my-3" role="alert">
+        You cannot delete your own account.
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <h1 class="my-3" th:text="${user.username}"></h1>
+
+    <dl class="row">
+        <dt class="col-sm-3">Id</dt>
+        <dd class="col-sm-9" th:text="${user.id}"></dd>
+
+        <dt class="col-sm-3">Email</dt>
+        <dd class="col-sm-9" th:text="${user.email}"></dd>
+
+        <dt class="col-sm-3">Role</dt>
+        <dd class="col-sm-9" th:text="${user.role}"></dd>
+
+        <dt class="col-sm-3">Enabled</dt>
+        <dd class="col-sm-9" th:text="${user.enabled}"></dd>
+
+        <dt class="col-sm-3">Two-factor</dt>
+        <dd class="col-sm-9" th:text="${user.twoFactorEnabled}"></dd>
+
+        <dt class="col-sm-3">Created</dt>
+        <dd class="col-sm-9" th:text="${user.createdAt}"></dd>
+
+        <dt class="col-sm-3">Last login</dt>
+        <dd class="col-sm-9" th:text="${user.lastLoginAt} ?: 'never'"></dd>
+    </dl>
+
+    <div class="d-flex gap-2">
+        <a class="btn btn-dark" th:href="@{'/admin/users/' + ${user.id} + '/update'}">Edit</a>
+        <form th:action="@{'/admin/users/' + ${user.id}}" method="post" onsubmit="return confirm('Delete this user?');">
+            <button type="submit" name="delete" class="btn btn-outline-danger">Delete</button>
+        </form>
+        <a href="/admin/users" class="btn btn-link">Back to list</a>
+    </div>
+</div>
+
+<div th:insert="~{fragments/footer :: footer}"></div>
+</html>

--- a/src/main/resources/templates/admin/users.html
+++ b/src/main/resources/templates/admin/users.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<div th:insert="~{fragments/header :: header}"></div>
+<div th:insert="~{fragments/navbar :: navbar}"></div>
+
+<div class="container">
+    <div th:if="${param.created}" class="alert alert-success alert-dismissible fade show my-3" role="alert">
+        User created
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <div th:if="${param.updated}" class="alert alert-success alert-dismissible fade show my-3" role="alert">
+        User updated
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <div th:if="${param.deleted}" class="alert alert-success alert-dismissible fade show my-3" role="alert">
+        User deleted
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <div th:if="${param.notFound}" class="alert alert-info alert-dismissible fade show my-3" role="alert">
+        User not found
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div class="d-flex justify-content-between align-items-center my-3">
+        <h1>Users</h1>
+        <a class="btn btn-dark" href="/admin/users/new">New user</a>
+    </div>
+
+    <table class="table table-hover">
+        <thead>
+            <tr>
+                <th>Id</th>
+                <th>Username</th>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Enabled</th>
+                <th>2FA</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr th:each="user : ${users}">
+                <td th:text="${user.id}"></td>
+                <td th:text="${user.username}"></td>
+                <td th:text="${user.email}"></td>
+                <td th:text="${user.role}"></td>
+                <td>
+                    <span th:if="${user.enabled}" class="badge bg-success">Yes</span>
+                    <span th:unless="${user.enabled}" class="badge bg-secondary">No</span>
+                </td>
+                <td>
+                    <span th:if="${user.twoFactorEnabled}" class="badge bg-info">On</span>
+                    <span th:unless="${user.twoFactorEnabled}" class="badge bg-secondary">Off</span>
+                </td>
+                <td class="text-end">
+                    <a class="btn btn-sm btn-outline-dark" th:href="@{'/admin/users/' + ${user.id}}">View</a>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div th:insert="~{fragments/footer :: footer}"></div>
+</html>

--- a/src/main/resources/templates/auth/forgotPassword.html
+++ b/src/main/resources/templates/auth/forgotPassword.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Forgot password</title>
+</head>
+<body>
+<div class="container">
+    <div class="col-md-4 mx-auto" style="margin-top: 6rem;">
+        <h1 class="mb-3">Forgot password</h1>
+        <p class="text-muted">Enter the email on your account. If we find it, we'll send a reset link.</p>
+
+        <div th:if="${param.submitted}" class="alert alert-success">
+            If that email matches an account, a reset link has been sent.
+        </div>
+
+        <form th:action="@{/forgot-password}" th:object="${forgotPassword}" method="post" class="needs-validation" novalidate>
+            <div class="mb-3">
+                <label for="email" class="form-label">Email</label>
+                <input class="form-control" type="email" id="email" th:field="*{email}" required autofocus>
+                <div class="text-danger small" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></div>
+            </div>
+            <div class="d-grid">
+                <button class="btn btn-dark" type="submit">Send reset link</button>
+            </div>
+        </form>
+
+        <div class="mt-3 text-center">
+            <a href="/login">Back to sign in</a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Sign in</title>
+</head>
+<body>
+<div class="container">
+    <div class="col-md-4 mx-auto" style="margin-top: 6rem;">
+        <h1 class="mb-4">Sign in</h1>
+
+        <div th:if="${param.error}" class="alert alert-danger">Invalid username or password.</div>
+        <div th:if="${param.invalidCode}" class="alert alert-danger">Invalid or expired verification code.</div>
+        <div th:if="${param.logout}" class="alert alert-success">Signed out.</div>
+        <div th:if="${param.passwordReset}" class="alert alert-success">Password reset. Please sign in.</div>
+        <div th:if="${param.invalidResetToken}" class="alert alert-warning">That reset link is invalid or expired.</div>
+
+        <form th:action="@{/login}" method="post" class="needs-validation" novalidate>
+            <div class="mb-3">
+                <label for="username" class="form-label">Username</label>
+                <input class="form-control" type="text" id="username" name="username" required autofocus>
+            </div>
+            <div class="mb-3">
+                <label for="password" class="form-label">Password</label>
+                <input class="form-control" type="password" id="password" name="password" required>
+            </div>
+            <div class="d-grid">
+                <button class="btn btn-dark" type="submit">Sign in</button>
+            </div>
+        </form>
+
+        <div class="mt-3 text-center">
+            <a href="/forgot-password">Forgot your password?</a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/auth/resetPassword.html
+++ b/src/main/resources/templates/auth/resetPassword.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Reset password</title>
+</head>
+<body>
+<div class="container">
+    <div class="col-md-4 mx-auto" style="margin-top: 6rem;">
+        <h1 class="mb-3">Reset password</h1>
+
+        <form th:action="@{/reset-password}" th:object="${resetPassword}" method="post" class="needs-validation" novalidate>
+            <input type="hidden" th:field="*{token}" />
+            <div class="mb-3">
+                <label for="password" class="form-label">New password</label>
+                <input class="form-control" type="password" id="password" th:field="*{password}" minlength="8" required>
+                <div class="text-danger small" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></div>
+            </div>
+            <div class="mb-3">
+                <label for="confirmPassword" class="form-label">Confirm new password</label>
+                <input class="form-control" type="password" id="confirmPassword" th:field="*{confirmPassword}" minlength="8" required>
+                <div class="text-danger small" th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></div>
+            </div>
+            <div class="d-grid">
+                <button class="btn btn-dark" type="submit">Set new password</button>
+            </div>
+        </form>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/auth/verify2fa.html
+++ b/src/main/resources/templates/auth/verify2fa.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Verify</title>
+</head>
+<body>
+<div class="container">
+    <div class="col-md-4 mx-auto" style="margin-top: 6rem;">
+        <h1 class="mb-3">Two-factor verification</h1>
+        <p class="text-muted">We sent a 6-digit code to your email. Enter it below to finish signing in.</p>
+
+        <form th:action="@{/verify-2fa}" th:object="${twoFactor}" method="post" class="needs-validation" novalidate>
+            <div class="mb-3">
+                <label for="code" class="form-label">Verification code</label>
+                <input class="form-control" type="text" id="code" th:field="*{code}"
+                       inputmode="numeric" pattern="\d{6}" maxlength="6" minlength="6" required autofocus>
+                <div class="text-danger small" th:if="${#fields.hasErrors('code')}" th:errors="*{code}"></div>
+            </div>
+            <div class="d-grid">
+                <button class="btn btn-dark" type="submit">Verify</button>
+            </div>
+        </form>
+
+        <div class="mt-3 text-center">
+            <a href="/login">Cancel and sign in again</a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/dashboard/dashboard.html
+++ b/src/main/resources/templates/dashboard/dashboard.html
@@ -1,104 +1,351 @@
-<!-- Header -->
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
 <!-- Header fragment -->
 <div th:insert="~{fragments/header :: header}"></div>
 <!-- Navbar fragment -->
 <div th:insert="~{fragments/navbar :: navbar}"></div>
 
-<h1 class="my-3 text-center" th:text="|Dash Board|">Customer List</h1>
+<div class="container-fluid px-4 py-3">
 
-<!-- Charts CSS CDN-->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/charts.css/dist/charts.min.css">
-
-<!-- Boostrap Grid Structure -->
-<div class="container">
-
-  <div class="row">
-    <!-- Last three months sales bars graph card -->
-    <div class="card p-1 flex-grow-1 col-md-8" style="width: 25vh; height: 30vw;">
-      <div class="card-body">
-        <!-- Checks if there is sales data to display, otherwise display no sales data to display message -->
-        <div class="salesGraph" th:if="${!lastThreeMonthsSales.lastThreeMonthsSales.isEmpty()}">
-          <!-- Using ChartsCSS framework -->
-          <table class="charts-css column show-heading show-labels data-spacing-20">
-            <caption class="text-center"> Last Three Month Sales </caption>
-            <thead>
-              <tr>
-                <th scope="col">Date</th>
-                <th scope="col">Total Sales</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr th:each="monthSales : ${lastThreeMonthsSales.lastThreeMonthsSales}">
-                <th scope="row" th:text="${monthSales.getMonth()}">January</th>
-                <td th:style="|--size: ${monthSales.getTotal() / lastThreeMonthsSales.getMaxValue()}|"
-                  th:text="${#numbers.formatCurrency(monthSales.getTotal())}">$100,000</td>
-              </tr>
-            </tbody>
-          </table>
+    <!-- Row 1: KPI cards -->
+    <div class="row g-3 mb-3">
+        <div class="col-md-3">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <div class="d-flex align-items-center text-muted small mb-1">
+                        <i class="bi bi-cart me-2"></i>Open sales orders
+                    </div>
+                    <div class="h3 mb-0" th:text="${kpiSo?.count ?: 0}">0</div>
+                    <div class="text-muted small" th:text="${'$' + #numbers.formatDecimal(kpiSo?.totalValue ?: 0, 0, 'COMMA', 2, 'POINT') + ' pending'}">$0</div>
+                </div>
+            </div>
         </div>
-        <div class="salesGraph" th:unless="${!lastThreeMonthsSales.lastThreeMonthsSales.isEmpty()}">
-          <h5 class="center">No sales data to display</h5>
+        <div class="col-md-3">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <div class="d-flex align-items-center text-muted small mb-1">
+                        <i class="bi bi-bag-check me-2"></i>Open purchase orders
+                    </div>
+                    <div class="h3 mb-0" th:text="${kpiPo?.count ?: 0}">0</div>
+                    <div class="text-muted small" th:text="${'$' + #numbers.formatDecimal(kpiPo?.totalValue ?: 0, 0, 'COMMA', 2, 'POINT') + ' on order'}">$0</div>
+                </div>
+            </div>
         </div>
-      </div>
+        <div class="col-md-3">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <div class="d-flex align-items-center text-muted small mb-1">
+                        <i class="bi bi-receipt me-2"></i>Pending receipts
+                    </div>
+                    <div class="h3 mb-0" th:text="${pendingGrns}">0</div>
+                    <div class="text-muted small">GRNs awaiting fulfillment</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <div class="d-flex align-items-center text-muted small mb-1">
+                        <i class="bi bi-exclamation-triangle text-warning me-2"></i>Active backorders
+                    </div>
+                    <div class="h3 mb-0" th:text="${kpiBackorders?.count ?: 0}">0</div>
+                    <div class="text-muted small" th:text="${'$' + #numbers.formatDecimal(kpiBackorders?.totalValue ?: 0, 0, 'COMMA', 2, 'POINT') + ' shorted'}">$0</div>
+                </div>
+            </div>
+        </div>
     </div>
-    <!-- End of three months sales bars graph card -->
 
-
-    <!-- Last Three Months Average card -->
-    <div class="card col-md-4">
-      <div class="card-body">
-        <!-- Checks if there is sales data to display, otherwise display no sales data to display message -->
-        <div class="salesGraph" th:if="${!lastThreeMonthsSales.lastThreeMonthsSales.isEmpty()}">
-          <h5 class="card-title text-center">Three Months Average Sales</h5>
-          <p class="card-text text-center"
-            th:text="${#numbers.formatCurrency(lastThreeMonthsSales.getThreeMonthsAverageSales())}">
-            Customer List</p>
+    <!-- Row 2: Inventory snapshot tiles -->
+    <div class="row g-3 mb-3">
+        <div class="col-md-3">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <div class="text-muted small mb-1"><i class="bi bi-cash-stack me-2"></i>Inventory value</div>
+                    <div class="h4 mb-0" th:text="${'$' + #numbers.formatDecimal(inventory?.totalValue ?: 0, 0, 'COMMA', 2, 'POINT')}">$0</div>
+                </div>
+            </div>
         </div>
-        <div class="salesGraph" th:unless="${!lastThreeMonthsSales.lastThreeMonthsSales.isEmpty()}">
-          <h5 class="card-title text-center">No sales data to display</h5>
+        <div class="col-md-3">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <div class="text-muted small mb-1"><i class="bi bi-boxes me-2"></i>Units on hand</div>
+                    <div class="h4 mb-0" th:text="${#numbers.formatInteger(inventory?.totalUnits ?: 0, 0, 'COMMA')}">0</div>
+                </div>
+            </div>
         </div>
-      </div>
+        <div class="col-md-3">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <div class="text-muted small mb-1"><i class="bi bi-x-circle text-danger me-2"></i>Out-of-stock SKUs</div>
+                    <div class="h4 mb-0" th:text="${inventory?.oosCount ?: 0}">0</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <div class="text-muted small mb-1"><i class="bi bi-graph-down-arrow text-warning me-2"></i>Low-stock SKUs</div>
+                    <div class="h4 mb-0" th:text="${inventory?.lowStockCount ?: 0}">0</div>
+                    <div class="text-muted small">WoI &lt; 2</div>
+                </div>
+            </div>
+        </div>
     </div>
-    <!-- END Last Three Months Average card -->
-  </div>
 
-  <div class="row">
-    <!-- Top Five movers Div-->
-    <div class="card p-2">
-      <div class="card-body">
-        <!-- Checks if there is stock level data to display, otherwise display no stock level data to display message -->
-        <div class="salesGraph" th:if="${!topFiveMovers.isEmpty()}">
-          <h5 class="my-3 text-center card-title" th:text="|Top 5 Movers|">Customer List</h5>
-          <table class="table">
-            <thead>
-              <tr>
-                <th scope="col">Sku</th>
-                <th scope="col">Description</th>
-                <th scope="col">Qty on Hand</th>
-                <th scope="col">Average Week Sales</th>
-                <th scope="col">Weeks of Inventory</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr th:each="mover : ${topFiveMovers}">
-                <th scope="row" th:text="${mover.getSku()}">101010</th>
-                <td th:text="${mover.getDescription()}">Iphone 14</td>
-                <td th:text="${mover.getQtyOnHand()}">190</td>
-                <td th:text="${mover.getAverageWeekSales()}">40</td>
-                <td th:text="${mover.getWeeksOfInventory()}">4.0</td>
-              </tr>
-            </tbody>
-          </table>
+    <!-- Row 3: Daily sales trend + Ops stats -->
+    <div class="row g-3 mb-3">
+        <div class="col-md-8">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Daily sales — last 30 days</h5>
+                    <div th:if="${dailySales != null and !dailySales.isEmpty()}">
+                        <canvas id="dailySalesChart" height="100"></canvas>
+                    </div>
+                    <div th:if="${dailySales == null or dailySales.isEmpty()}" class="text-muted small">
+                        No sales in the last 30 days.
+                    </div>
+                </div>
+            </div>
         </div>
-        <div class="salesGraph" th:unless="${!topFiveMovers.isEmpty()}">
-          <h5 class="my-3 text-center card-title">No stock level data to display</h5>
+        <div class="col-md-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Operations</h5>
+                    <div class="d-flex justify-content-between border-bottom py-2">
+                        <span><i class="bi bi-list-check me-2"></i>Pending picking jobs</span>
+                        <strong th:text="${pendingPicks}">0</strong>
+                    </div>
+                    <div class="d-flex justify-content-between border-bottom py-2">
+                        <span><i class="bi bi-arrow-down-square me-2"></i>Stock on floor</span>
+                        <strong th:text="${stockOnFloor}">0</strong>
+                    </div>
+                    <div class="d-flex justify-content-between py-2">
+                        <span><i class="bi bi-receipt me-2"></i>Pending GRNs</span>
+                        <strong th:text="${pendingGrns}">0</strong>
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
     </div>
-    <!-- END Stock Levels Table  -->
-  </div>
+
+    <!-- Row 4: Top vendors + PO status -->
+    <div class="row g-3 mb-3">
+        <div class="col-md-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Top vendors — YTD spend</h5>
+                    <div th:if="${topVendors != null and !topVendors.isEmpty()}">
+                        <canvas id="vendorSpendChart" height="160"></canvas>
+                    </div>
+                    <div th:if="${topVendors == null or topVendors.isEmpty()}" class="text-muted small">
+                        No PO spend this year yet.
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">PO status breakdown</h5>
+                    <div th:if="${poStatusBuckets != null and !poStatusBuckets.isEmpty()}">
+                        <canvas id="poStatusChart" height="160"></canvas>
+                    </div>
+                    <div th:if="${poStatusBuckets == null or poStatusBuckets.isEmpty()}" class="text-muted small">
+                        No purchase orders.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Row 5: Reorder list + Top movers -->
+    <div class="row g-3 mb-3">
+        <div class="col-md-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Items to reorder</h5>
+                    <div th:if="${reorderItems == null or reorderItems.isEmpty()}" class="text-muted small">
+                        Nothing critical to reorder — every fast-moving item either has stock or an open PO.
+                    </div>
+                    <table th:if="${reorderItems != null and !reorderItems.isEmpty()}" class="table table-sm align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th>SKU</th>
+                                <th>Description</th>
+                                <th>Vendor</th>
+                                <th class="text-end">QoH</th>
+                                <th class="text-end">Wk velocity</th>
+                                <th class="text-end">WoI</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr th:each="item : ${reorderItems}">
+                                <td th:text="${item.sku}">123</td>
+                                <td th:text="${item.description}">Desc</td>
+                                <td th:text="${item.vendorName}">Vendor</td>
+                                <td class="text-end" th:text="${item.qtyOnHand}">0</td>
+                                <td class="text-end" th:text="${item.weeklyVelocity}">0</td>
+                                <td class="text-end fw-semibold text-danger" th:text="${item.weeksOfInventory}">0</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Top 5 movers</h5>
+                    <div th:if="${topFiveMovers == null or topFiveMovers.isEmpty()}" class="text-muted small">
+                        No sales velocity recorded.
+                    </div>
+                    <table th:if="${topFiveMovers != null and !topFiveMovers.isEmpty()}" class="table table-sm align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th>SKU</th>
+                                <th>Description</th>
+                                <th class="text-end">QoH</th>
+                                <th class="text-end">Avg wk sales</th>
+                                <th class="text-end">WoI</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr th:each="mover : ${topFiveMovers}">
+                                <td th:text="${mover.sku}">000</td>
+                                <td th:text="${mover.description}">Desc</td>
+                                <td class="text-end" th:text="${mover.qtyOnHand}">0</td>
+                                <td class="text-end" th:text="${mover.averageWeekSales}">0</td>
+                                <td class="text-end" th:text="${mover.weeksOfInventory}">0</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Row 6: PO aging table -->
+    <div class="row g-3 mb-3">
+        <div class="col-12">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Purchase orders aging &gt; 30 days</h5>
+                    <div th:if="${agingPos == null or agingPos.isEmpty()}" class="text-muted small">
+                        No POs older than 30 days are still open.
+                    </div>
+                    <table th:if="${agingPos != null and !agingPos.isEmpty()}" class="table table-sm align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th>PO #</th>
+                                <th>Vendor</th>
+                                <th>Date</th>
+                                <th class="text-end">Age (days)</th>
+                                <th>Status</th>
+                                <th class="text-end">Value</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr th:each="po : ${agingPos}">
+                                <td><a th:href="@{'/purchase-orders/' + ${po.id}}" th:text="${po.id}">42</a></td>
+                                <td th:text="${po.vendorName}">Vendor</td>
+                                <td th:text="${po.date}">2026-01-01</td>
+                                <td class="text-end fw-semibold" th:classappend="${po.ageDays > 60 ? 'text-danger' : 'text-warning'}" th:text="${po.ageDays}">0</td>
+                                <td>
+                                    <span th:if="${po.status == 0}" class="badge bg-secondary">IN TRANSIT</span>
+                                    <span th:if="${po.status == 2}" class="badge bg-warning text-dark">PARTIALLY RECEIVED</span>
+                                </td>
+                                <td class="text-end" th:text="${'$' + #numbers.formatDecimal(po.total ?: 0, 0, 'COMMA', 2, 'POINT')}">$0</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
 
 </div>
 
-<!-- Header fragment -->
+<!-- Chart.js -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<script th:inline="javascript">
+    /*<![CDATA[*/
+    (function () {
+        const dailySalesRaw   = /*[[${dailySales}]]*/   [];
+        const topVendorsRaw   = /*[[${topVendors}]]*/   [];
+        const poStatusRaw     = /*[[${poStatusBuckets}]]*/ [];
+
+        // --- Daily sales line chart ---
+        const dailyEl = document.getElementById('dailySalesChart');
+        if (dailyEl && dailySalesRaw.length) {
+            new Chart(dailyEl, {
+                type: 'line',
+                data: {
+                    labels: dailySalesRaw.map(r => r.day),
+                    datasets: [{
+                        label: 'Sales',
+                        data: dailySalesRaw.map(r => r.total),
+                        borderColor: '#0d6efd',
+                        backgroundColor: 'rgba(13,110,253,0.15)',
+                        fill: true,
+                        tension: 0.25,
+                        pointRadius: 2
+                    }]
+                },
+                options: {
+                    plugins: { legend: { display: false } },
+                    scales: {
+                        y: { beginAtZero: true, ticks: { callback: v => '$' + v.toLocaleString() } }
+                    }
+                }
+            });
+        }
+
+        // --- Top vendors horizontal bar chart ---
+        const vendorEl = document.getElementById('vendorSpendChart');
+        if (vendorEl && topVendorsRaw.length) {
+            new Chart(vendorEl, {
+                type: 'bar',
+                data: {
+                    labels: topVendorsRaw.map(r => r.vendorName),
+                    datasets: [{
+                        label: 'YTD spend',
+                        data: topVendorsRaw.map(r => r.total),
+                        backgroundColor: ['#0d6efd', '#6610f2', '#6f42c1', '#d63384', '#fd7e14']
+                    }]
+                },
+                options: {
+                    indexAxis: 'y',
+                    plugins: { legend: { display: false } },
+                    scales: {
+                        x: { beginAtZero: true, ticks: { callback: v => '$' + v.toLocaleString() } }
+                    }
+                }
+            });
+        }
+
+        // --- PO status doughnut ---
+        const poEl = document.getElementById('poStatusChart');
+        if (poEl && poStatusRaw.length) {
+            const statusLabels = { 0: 'In transit', 1: 'Received', 2: 'Partially received' };
+            const statusColors = { 0: '#6c757d', 1: '#198754', 2: '#ffc107' };
+            new Chart(poEl, {
+                type: 'doughnut',
+                data: {
+                    labels: poStatusRaw.map(r => statusLabels[r.status] || ('Status ' + r.status)),
+                    datasets: [{
+                        data: poStatusRaw.map(r => r.count),
+                        backgroundColor: poStatusRaw.map(r => statusColors[r.status] || '#adb5bd')
+                    }]
+                },
+                options: {
+                    plugins: { legend: { position: 'bottom' } }
+                }
+            });
+        }
+    })();
+    /*]]>*/
+</script>
+
+<!-- Footer fragment -->
 <div th:insert="~{fragments/footer :: footer}"></div>
+</html>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,4 +1,4 @@
-<!-- Bootsrap's JS -->
+<!-- Bootstrap JS bundle -->
 <script th:fragment="footer" src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm"
     crossorigin="anonymous"></script>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,10 +1,56 @@
 <!DOCTYPE html>
-<html lang="en" th:fragment="header">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:fragment="header">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- Bootstrap's CSS CDN -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
-    <title th:text="${title}">Document</title>    
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <title th:text="${title}">Document</title>
+    <style>
+        :root { --wms-sidebar-w: 240px; --wms-topbar-h: 56px; }
+        body {
+            background: #f6f8fa;
+            padding-left: var(--wms-sidebar-w);
+            padding-top: var(--wms-topbar-h);
+            min-height: 100vh;
+        }
+        .wms-sidebar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            width: var(--wms-sidebar-w);
+            overflow-y: auto;
+            z-index: 1030;
+        }
+        .wms-sidebar .nav-link {
+            color: rgba(255, 255, 255, 0.75);
+            border-radius: .375rem;
+            padding: .5rem .75rem;
+        }
+        .wms-sidebar .nav-link:hover,
+        .wms-sidebar .nav-link.active {
+            color: #fff;
+            background-color: rgba(255, 255, 255, 0.08);
+        }
+        .wms-sidebar .nav-link i { width: 1.25rem; }
+        .wms-sidebar .nav-link .bi-chevron-down { transition: transform .15s ease; }
+        .wms-sidebar .nav-link[aria-expanded="true"] .bi-chevron-down { transform: rotate(180deg); }
+        .wms-sidebar .submenu .nav-link { padding-left: 2.5rem; font-size: .9rem; }
+        .wms-topbar {
+            position: fixed;
+            top: 0;
+            left: var(--wms-sidebar-w);
+            right: 0;
+            height: var(--wms-topbar-h);
+            z-index: 1020;
+        }
+        @media (max-width: 767.98px) {
+            body { padding-left: 0; }
+            .wms-sidebar { transform: translateX(-100%); }
+            .wms-topbar { left: 0; }
+        }
+    </style>
 </head>
 <body>
+</html>

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -1,125 +1,183 @@
-<nav class="navbar navbar-expand-lg bg-body-tertiary" th:fragment="navbar">
-    <div class="container-fluid">
-      <a class="navbar-brand" href="#">Navbar</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="/">Home</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#">Link</a>
-          </li>
-          <!-- Dropdown Tab -->
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Customers
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="/customers/new-customer">New Customer</a></li>
-              <li><a class="dropdown-item" href="/customers">Customers</a></li>
-            </ul>
-          </li>
-          <!-- Dropdown Tab End -->
-          <!-- Dropdown Tab -->
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Vendors
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="/vendors/new-vendor">New Vendor</a></li>
-              <li><a class="dropdown-item" href="/vendors">Vendors</a></li>
-            </ul>
-          </li>
-          <!-- Report Tab -->
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Reports
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="/reports/sales-order-by-customer">Sales Order By Customer</a></li>
-              <li><a class="dropdown-item" href="/reports/sales-order-details">Sales Order By Number</a></li>
-              <li><a class="dropdown-item" href="/reports/pending-sales-orders-by-year-month">Pending Sales Order By Year and Month</a></li>
-              <li><a class="dropdown-item" href="/reports/stock-level-report-by-vendor">Stock Level Report By Vendor</a></li>
-              <li><a class="dropdown-item" href="/reports/back-order-report-by-year">Back Order Report By Year</a></li>
-            </ul>
-          </li>
-          <!-- END Report Tab -->
-          <!-- Sales Order Tab -->
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Sales Orders
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="/sales-orders/new-sales-order">New Sales Order</a></li>
-              <li><a class="dropdown-item" href="/sales-orders">Sales Orders</a></li>
-              <li><a class="dropdown-item" href="/sales-orders/pending">Pending Sales Orders</a></li>
-            </ul>
-          </li>
-          <!-- END Sales Order Tab -->
-          <!-- Purchase Order Tab -->
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Purchase Orders
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="/purchase-orders/new-purchase-order">New Purchase Order</a></li>
-              <li><a class="dropdown-item" href="/purchase-orders">Purchase Orders</a></li>
-              <li><a class="dropdown-item" href="/purchase-orders/pending">Pending Purchase Orders</a></li>
-            </ul>
-          </li>
-          <!-- END Purchase Order Tab -->
-          <!-- Goods Receipt Note Tab -->
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Goods Receipt Notes
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="/goods-receipt-notes/search-purchase-order">Search Purchase Order</a></li>
-              <li><a class="dropdown-item" href="/goods-receipt-notes/pending-goods-receipt-notes">Pending Goods Receipt Notes</a></li>
-              <li><a class="dropdown-item" href="/goods-receipt-notes/fulfilled-goods-receipt-notes">Fulfilled Goods Receipt Notes</a></li>
-            </ul>
-          </li>
-          <!-- END Goods Receipt Notes-->
-           <!-- Put Away Tasks Tab -->
-           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Put Away Tasks
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="/put-aways/floor">Put Away Tasks On Floor</a></li>
-              <li><a class="dropdown-item" href="/put-aways/search-warehouse-section">Search Put Away Tasks</a></li>
-            </ul>
-          </li>
-          <!-- END Goods Receipt Notes-->
-          <!-- Picking Job Tab -->
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            Picking Jobs
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="/picking-jobs">Picking Jobs</a></li>
-              <li><a class="dropdown-item" href="#">Another action</a></li>
-            </ul>
-          </li>
-           <!-- Dropdown Tab -->
-           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Items
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="/items/new-item">New Item</a></li>
-              <li><a class="dropdown-item" href="/items">Items</a></li>
-            </ul>
-          </li>
-          <!-- END Picking Job Tab -->
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<body>
+<div th:fragment="navbar">
+
+    <!-- Sidebar (md+) — fixed-position left rail -->
+    <aside class="wms-sidebar bg-dark text-white p-3 d-none d-md-block">
+        <a href="/" class="text-white text-decoration-none d-flex align-items-center mb-4">
+            <i class="bi bi-box-seam fs-4 me-2"></i>
+            <span class="fs-5 fw-semibold">Warehouse</span>
+        </a>
+        <ul class="nav nav-pills flex-column gap-1">
+            <li class="nav-item">
+                <a class="nav-link" href="/"><i class="bi bi-speedometer2 me-2"></i>Dashboard</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link d-flex align-items-center justify-content-between" data-bs-toggle="collapse" href="#nav-customers" role="button" aria-expanded="false">
+                    <span><i class="bi bi-people me-2"></i>Customers</span>
+                    <i class="bi bi-chevron-down small"></i>
+                </a>
+                <div class="collapse submenu" id="nav-customers">
+                    <ul class="nav flex-column">
+                        <li class="nav-item"><a class="nav-link" href="/customers">All customers</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/customers/new-customer">New customer</a></li>
+                    </ul>
+                </div>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link d-flex align-items-center justify-content-between" data-bs-toggle="collapse" href="#nav-vendors" role="button" aria-expanded="false">
+                    <span><i class="bi bi-truck me-2"></i>Vendors</span>
+                    <i class="bi bi-chevron-down small"></i>
+                </a>
+                <div class="collapse submenu" id="nav-vendors">
+                    <ul class="nav flex-column">
+                        <li class="nav-item"><a class="nav-link" href="/vendors">All vendors</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/vendors/new-vendor">New vendor</a></li>
+                    </ul>
+                </div>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link d-flex align-items-center justify-content-between" data-bs-toggle="collapse" href="#nav-items" role="button" aria-expanded="false">
+                    <span><i class="bi bi-box me-2"></i>Items</span>
+                    <i class="bi bi-chevron-down small"></i>
+                </a>
+                <div class="collapse submenu" id="nav-items">
+                    <ul class="nav flex-column">
+                        <li class="nav-item"><a class="nav-link" href="/items">All items</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/items/new-item">New item</a></li>
+                    </ul>
+                </div>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link d-flex align-items-center justify-content-between" data-bs-toggle="collapse" href="#nav-sales" role="button" aria-expanded="false">
+                    <span><i class="bi bi-cart me-2"></i>Sales orders</span>
+                    <i class="bi bi-chevron-down small"></i>
+                </a>
+                <div class="collapse submenu" id="nav-sales">
+                    <ul class="nav flex-column">
+                        <li class="nav-item"><a class="nav-link" href="/sales-orders">All orders</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/sales-orders/pending">Pending</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/sales-orders/new-sales-order">New order</a></li>
+                    </ul>
+                </div>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link d-flex align-items-center justify-content-between" data-bs-toggle="collapse" href="#nav-purchases" role="button" aria-expanded="false">
+                    <span><i class="bi bi-bag-check me-2"></i>Purchase orders</span>
+                    <i class="bi bi-chevron-down small"></i>
+                </a>
+                <div class="collapse submenu" id="nav-purchases">
+                    <ul class="nav flex-column">
+                        <li class="nav-item"><a class="nav-link" href="/purchase-orders">All orders</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/purchase-orders/pending">Pending</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/purchase-orders/new-purchase-order">New order</a></li>
+                    </ul>
+                </div>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link d-flex align-items-center justify-content-between" data-bs-toggle="collapse" href="#nav-grn" role="button" aria-expanded="false">
+                    <span><i class="bi bi-receipt me-2"></i>Receipt notes</span>
+                    <i class="bi bi-chevron-down small"></i>
+                </a>
+                <div class="collapse submenu" id="nav-grn">
+                    <ul class="nav flex-column">
+                        <li class="nav-item"><a class="nav-link" href="/goods-receipt-notes/search-purchase-order">Search PO</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/goods-receipt-notes/pending-goods-receipt-notes">Pending</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/goods-receipt-notes/fulfilled-goods-receipt-notes">Fulfilled</a></li>
+                    </ul>
+                </div>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link d-flex align-items-center justify-content-between" data-bs-toggle="collapse" href="#nav-putaway" role="button" aria-expanded="false">
+                    <span><i class="bi bi-arrow-down-square me-2"></i>Put-away</span>
+                    <i class="bi bi-chevron-down small"></i>
+                </a>
+                <div class="collapse submenu" id="nav-putaway">
+                    <ul class="nav flex-column">
+                        <li class="nav-item"><a class="nav-link" href="/put-aways/floor">On floor</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/put-aways/search-warehouse-section">By section</a></li>
+                    </ul>
+                </div>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="/picking-jobs"><i class="bi bi-list-check me-2"></i>Picking jobs</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link d-flex align-items-center justify-content-between" data-bs-toggle="collapse" href="#nav-reports" role="button" aria-expanded="false">
+                    <span><i class="bi bi-bar-chart me-2"></i>Reports</span>
+                    <i class="bi bi-chevron-down small"></i>
+                </a>
+                <div class="collapse submenu" id="nav-reports">
+                    <ul class="nav flex-column">
+                        <li class="nav-item"><a class="nav-link" href="/reports/sales-order-by-customer">Sales by customer</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/reports/sales-order-details">Sales by number</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/reports/pending-sales-orders-by-year-month">Pending sales</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/reports/stock-level-report-by-vendor">Stock level</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/reports/back-order-report-by-year">Backorders</a></li>
+                    </ul>
+                </div>
+            </li>
+            <li class="nav-item" sec:authorize="hasRole('ADMIN')">
+                <a class="nav-link d-flex align-items-center justify-content-between" data-bs-toggle="collapse" href="#nav-admin" role="button" aria-expanded="false">
+                    <span><i class="bi bi-shield-lock me-2"></i>Admin</span>
+                    <i class="bi bi-chevron-down small"></i>
+                </a>
+                <div class="collapse submenu" id="nav-admin">
+                    <ul class="nav flex-column">
+                        <li class="nav-item"><a class="nav-link" href="/admin/users">Users</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/admin/users/new">New user</a></li>
+                    </ul>
+                </div>
+            </li>
         </ul>
-        <!-- <form class="d-flex" role="search">
-          <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-          <button class="btn btn-outline-success" type="submit">Search</button>
-        </form> -->
-      </div>
+    </aside>
+
+    <!-- Offcanvas sidebar (mobile only) -->
+    <div class="offcanvas offcanvas-start bg-dark text-white wms-sidebar-offcanvas" tabindex="-1" id="wmsMobileSidebar" aria-labelledby="wmsMobileSidebarLabel" style="width: 240px;">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title text-white" id="wmsMobileSidebarLabel">
+                <i class="bi bi-box-seam me-2"></i>Warehouse
+            </h5>
+            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body p-3">
+            <ul class="nav nav-pills flex-column gap-1">
+                <li class="nav-item"><a class="nav-link text-white" href="/"><i class="bi bi-speedometer2 me-2"></i>Dashboard</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="/customers"><i class="bi bi-people me-2"></i>Customers</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="/vendors"><i class="bi bi-truck me-2"></i>Vendors</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="/items"><i class="bi bi-box me-2"></i>Items</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="/sales-orders"><i class="bi bi-cart me-2"></i>Sales orders</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="/purchase-orders"><i class="bi bi-bag-check me-2"></i>Purchase orders</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="/goods-receipt-notes/pending-goods-receipt-notes"><i class="bi bi-receipt me-2"></i>Receipt notes</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="/put-aways/floor"><i class="bi bi-arrow-down-square me-2"></i>Put-away</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="/picking-jobs"><i class="bi bi-list-check me-2"></i>Picking jobs</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="/reports/sales-order-by-customer"><i class="bi bi-bar-chart me-2"></i>Reports</a></li>
+                <li class="nav-item" sec:authorize="hasRole('ADMIN')"><a class="nav-link text-white" href="/admin/users"><i class="bi bi-shield-lock me-2"></i>Admin</a></li>
+            </ul>
+        </div>
     </div>
-  </nav>
+
+    <!-- Fixed topbar -->
+    <header class="wms-topbar bg-body-tertiary border-bottom d-flex align-items-center px-3">
+        <button class="btn btn-outline-secondary btn-sm d-md-none me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#wmsMobileSidebar" aria-controls="wmsMobileSidebar">
+            <i class="bi bi-list"></i>
+        </button>
+        <h1 class="h5 mb-0" th:text="${title} ?: 'Warehouse'">Dashboard</h1>
+        <div class="ms-auto d-flex align-items-center gap-3" sec:authorize="isAuthenticated()">
+            <span class="text-muted small d-none d-sm-inline">
+                <i class="bi bi-person-circle me-1"></i>
+                <span sec:authentication="name">user</span>
+            </span>
+            <form th:action="@{/logout}" method="post" class="m-0">
+                <button type="submit" class="btn btn-outline-dark btn-sm">
+                    <i class="bi bi-box-arrow-right me-1"></i>Sign out
+                </button>
+            </form>
+        </div>
+    </header>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Four cohesive iterations stacked into one branch. Each commit is independently revertable and reads top-to-bottom.

- **Auth (commit 2):** Spring Security 6 form login + opt-in email 2FA + forgot/reset password + `/admin/users` CRUD. New `User` entity, `UserService` doubling as `UserDetailsService`. `EmailService` falls back to console-logging when SMTP isn't configured so dev still works.
- **Sidebar (commit 3):** dark fixed-position sidebar with Bootstrap-Icons replaces the placeholder top navbar; mobile gets an offcanvas drawer. `Bootstrap.run()` now seeds order dates uniformly across `Jan 1` → last day of current month so dashboard queries against `CURRENT_DATE()` populate.
- **Dashboard (commit 4):** six-row workbench — KPI cards, inventory snapshot tiles, 30-day daily-sales line chart, top-vendors YTD bar chart, PO-status doughnut, items-to-reorder table, kept Top-5 Movers, PO-aging table. Backed by ~10 new native SQL aggregates + 7 interface-projection DTOs.

Total: 4 commits, ~60 files changed (~50 new), all built via `./mvnw compile` and smoke-tested end-to-end against the seeded H2 database (login → 2FA verification → admin user CRUD → dashboard widgets populated).

## Default seed credentials (DEV ONLY)

- `admin` / `Password123!` — `ROLE_ADMIN`, 2FA off
- `manager` / `Password123!` — `ROLE_USER`, 2FA on (verification code prints to the app log when SMTP is unset)

## Test plan

- [ ] `./mvnw spring-boot:run` — app starts; log shows the seed line `Seeded users: admin … and manager …`
- [ ] `localhost:8080` redirects to `/login`; sign in as `admin` and land on the new dashboard with KPI / inventory / charts / reorder / aging populated
- [ ] Sidebar collapses each section inline; resize below 768 px → hamburger triggers the offcanvas
- [ ] Sign out → sign in as `manager` → redirected to `/verify-2fa`; grab the code from the app log and verify; protected pages (e.g. `/sales-orders`) are blocked until the code is entered
- [ ] `/forgot-password` posts always return the same banner regardless of whether the email matches; reset URL prints to the log
- [ ] `/admin/users` requires ROLE_ADMIN (manager gets redirected); CRUD works; admin cannot self-delete
- [ ] Spot-check `/customers`, `/sales-orders`, `/items` render inside the new layout with the existing list/forms intact

## Heads-up

- Database is still in-memory H2; everything is lost on restart. The follow-up plan we already drafted (file-based H2 + Flyway baseline + `@Transactional` + tests + pagination + stock adjustments) addresses this — saved at `~/.claude/plans/improve-the-ux-ui-start-melodic-mountain.md` and indexed in project memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)