### PR TITLE
feat(bootstrap): make Bootstrap.run() idempotent (Phase 1.2)

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Bootstrap/Bootstrap.java
+++ b/src/main/java/com/example/warehouseManagement/Bootstrap/Bootstrap.java
@@ -132,6 +132,13 @@ public class Bootstrap implements CommandLineRunner {
 
         seedUsers();
 
+        // Skip demo-data seeding when the DB already has vendors. Mirrors the
+        // seedUsers() guard above so a file-based H2 doesn't accumulate duplicates
+        // across restarts.
+        if (vendorRepository.count() > 0) {
+            return;
+        }
+
         // Variables
         Random random = new SecureRandom();
         // Seed-data window: Jan 1 of the current year through the last day of the


### PR DESCRIPTION
## Summary
Stacked on top of #5. Adds an early-return guard to `Bootstrap.run()` so demo data isn't re-seeded on every restart now that H2 persists to disk.

```java
seedUsers();

if (vendorRepository.count() > 0) {
    return;
}
```

Mirrors the existing `seedUsers()` guard at `Bootstrap.java:476` — same pattern, same intent, one line below it.

## Why this is needed
With Phase 1.1 in place, the H2 file (`./data/warehouse.mv.db`) survives restarts. The previously unconditional demo seeding would re-insert 5 vendors, 10 customers, 200 sales orders, 150 purchase orders, 41 items, 1154 warehouse sections, etc. on **every** boot — producing duplicates and inflating dashboard metrics until the table got bloated enough to slow startup noticeably.

`vendorRepository.count()` is the simplest fingerprint: if vendors exist the demo run already happened, so we skip.

## Test plan
- [x] `rm -rf ./data && ./mvnw spring-boot:run` → seeds, prints `Customers: 10 / Vendors: 5 / Sales Order: 200 / ...`
- [x] Restart (no rm) → no Bootstrap output past `seedUsers()`; boots in ~1.8s; counts unchanged
- [ ] (Reviewer) Same restart loop — confirm dashboard KPIs are stable across restarts

## Stacking
- Base: `feature/persistence-baseline` (PR #5)
- After #5 merges, GitHub will retarget this PR to `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)