### PR TITLE
feat(services): @Transactional on multi-step write paths (Phase 1.3)

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Services/GoodsReceiptNoteImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/GoodsReceiptNoteImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.warehouseManagement.Domains.GoodsReceiptNote;
 import com.example.warehouseManagement.Domains.GoodsReceiptNote.GrnStatus;
@@ -92,6 +93,7 @@ public class GoodsReceiptNoteImpl implements GoodsReceiptNoteService {
     }
 
     @Override
+    @Transactional
     public GoodsReceiptNote fulfill(GoodsReceiptNote goodsReceiptNote, GoodsReceiptNoteDto goodsReceiptNoteDto) {
         PurchaseOrder purchaseOrder = goodsReceiptNote.getPurchaseOrder();
         int purchaseOrderLines = purchaseOrder.getPurchaseOrderLines().size();

--- a/src/main/java/com/example/warehouseManagement/Services/PickingJobServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PickingJobServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.warehouseManagement.Domains.Backorder;
 import com.example.warehouseManagement.Domains.PickingJob;
@@ -79,6 +80,7 @@ public class PickingJobServiceImpl implements PickingJobService {
      * if not, it will create another picking job line for the backorder 
      */
     @Override
+    @Transactional
     public PickingJob fulfill(PickingJob pickingJob, PickingJobDto pickingJobDto) {
         //Collections to collect fulfilled and not fulfilled picking job lines
         List<PickingJobLine> pickingJobDtoLinesForBackOrders = new ArrayList<>();

--- a/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.warehouseManagement.Domains.GoodsReceiptNote;
 import com.example.warehouseManagement.Domains.GoodsReceiptNote.GrnStatus;
@@ -87,6 +88,7 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
      * @return
      */
     @Override
+    @Transactional
     public PurchaseOrder updateById(Long id, PurchaseOrder purchaseOrder) throws PurchaseOrderNotFoundException, ReceivedOrderModificationException {
         if (purchaseOrderRepository.findById(id).isEmpty()) {
             throw new PurchaseOrderNotFoundException();
@@ -134,6 +136,7 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
      * Persists a Purchase order in the dba
      */
     @Override
+    @Transactional
     public PurchaseOrder save(PurchaseOrder purchaseOrder) {
         PurchaseOrder po = purchaseOrderRepository.save(purchaseOrder);
         // Adds goods receipt note
@@ -161,6 +164,7 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
      * Delete a persisted purchase order from the DBA
      */
     @Override
+    @Transactional
     public void delete(PurchaseOrder purchaseOrder) {
         purchaseOrderRepository.delete(purchaseOrder);
     }

--- a/src/main/java/com/example/warehouseManagement/Services/SalesOrderServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/SalesOrderServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.warehouseManagement.Domains.Customer;
 import com.example.warehouseManagement.Domains.Item;
@@ -71,6 +72,7 @@ public class SalesOrderServiceImpl implements SalesOrderService {
     }
 
     @Override
+    @Transactional
     public SalesOrder updateById(Long id, SalesOrder salesOrder)
             throws SalesOrderNotFoundException, ShippedOrderModificationException {
         if (salesOrderRepository.findById(id).isEmpty()) {
@@ -124,6 +126,7 @@ public class SalesOrderServiceImpl implements SalesOrderService {
     }
 
     @Override
+    @Transactional
     public SalesOrder save(SalesOrder salesOrder) {
         // TODO: TEST WITHOUT PERSISTING CHILDS ENTITIES USING REPO SINCE PARENT CASCADE
         // TYPE IS ALL
@@ -147,6 +150,7 @@ public class SalesOrderServiceImpl implements SalesOrderService {
     }
 
     @Override
+    @Transactional
     public void delete(SalesOrder salesOrder) {
         salesOrderRepository.delete(salesOrder);
     }

--- a/src/main/java/com/example/warehouseManagement/Services/StockServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/StockServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.warehouseManagement.Domains.PickingJob;
 import com.example.warehouseManagement.Domains.PickingJobLine;
@@ -93,6 +94,7 @@ public class StockServiceImpl implements StockService {
     }
 
     @Override
+    @Transactional
     public void putAwayStocks(PutAwayTasksDtoWrapper wrapper, List<Stock> stocks) {
         for (int i=0; i<wrapper.getPutAwayTasks().size(); i++) {
             PutAwayTaskDto putAwayTaskDto = wrapper.getPutAwayTasks().get(i);


### PR DESCRIPTION
## Summary
Stacked on #6. Wraps every service method that performs more than one repository write per call with `@Transactional` (Spring), so a failure halfway through rolls back cleanly instead of leaving the DB in a partial state.

Closes the third and final step of **Phase 1: Production foundations**.

## What changed

| Service | Method | Why it needs a tx |
|---|---|---|
| `SalesOrderServiceImpl` | `save` | saves SO + creates PickingJob + persists PickingJobLines + saveAll SOLs |
| `SalesOrderServiceImpl` | `updateById` | per-line item/qty mutation + repository.save(existing) + extra `saveAll` for added lines |
| `SalesOrderServiceImpl` | `delete` | single repo call today, but listed in the plan so child-cascade growth stays atomic |
| `PurchaseOrderServiceImpl` | `save` | persists PO + GRN + each PO-line + each GRN-line |
| `PurchaseOrderServiceImpl` | `updateById` | per-line item/qty mutation + saves for new lines |
| `PurchaseOrderServiceImpl` | `delete` | (same reasoning as above) |
| `PickingJobServiceImpl` | `fulfill` | mutates lines, optionally creates a backorder PJ + lines + backorder rows + updates SO |
| `GoodsReceiptNoteImpl` | `fulfill` | per-line stock inserts + GRN-line saves + PO status flip + GRN save |
| `StockServiceImpl` | `putAwayStocks` | iterates DTOs, either moves a stock row or splits one into two and saves both |

Import added in each file: `org.springframework.transaction.annotation.Transactional` — keeps access to `rollbackFor` / `propagation` / `readOnly` if we need them later. Net diff: 5 imports + 9 annotations = **14 inserted lines, 0 removed**.

## Why
Before this change, every multi-step write executed under per-statement auto-commit. If `pickingJobLineRepository.saveAll` failed after the PickingJob row was inserted, the PJ stayed in the DB with no lines. Same risk for orphan GRNs when `goodsReceiptNoteLineRepository.save` throws partway through. With these annotations the whole operation is one transaction; an exception triggers rollback of every prior write in the same call.

## Test plan
- [x] `./mvnw -q compile` — clean.
- [x] `./mvnw spring-boot:run` — boots in ~5s (no DevTools restart drift), no schema-validation/tx-binding errors, `/login` returns HTTP 200.
- [ ] (Reviewer) Smoke-test through the UI: create a sales order, edit it, delete it; create a purchase order, fulfill its GRN; fulfill a picking job; do a put-away from the floor section. None should partially commit.

## Stacking
- Base: `feature/bootstrap-idempotent` (PR #6 → PR #5 → main).
- GitHub will retarget upward as the stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)