### PR TITLE
feat(bootstrap): make Bootstrap.run() idempotent (Phase 1.2, redo)

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Bootstrap/Bootstrap.java
+++ b/src/main/java/com/example/warehouseManagement/Bootstrap/Bootstrap.java
@@ -132,6 +132,13 @@ public class Bootstrap implements CommandLineRunner {
 
         seedUsers();
 
+        // Skip demo-data seeding when the DB already has vendors. Mirrors the
+        // seedUsers() guard above so a file-based H2 doesn't accumulate duplicates
+        // across restarts.
+        if (vendorRepository.count() > 0) {
+            return;
+        }
+
         // Variables
         Random random = new SecureRandom();
         // Seed-data window: Jan 1 of the current year through the last day of the


### PR DESCRIPTION
## Summary
Recovers the Phase 1.2 change after the original PR #6 merged into its (then-stacked) base branch instead of `main` — so `main` never received the idempotency guard even though GitHub marked #6 as merged. Rebased the single commit onto current `main`; it applies cleanly.

Adds an early return when `vendorRepository.count() > 0`, mirroring the existing `seedUsers()` guard:

```java
seedUsers();

if (vendorRepository.count() > 0) {
    return;
}
```

## Why it's still needed
PR #5 (file-based H2) is now on `main`, so the H2 file persists across restarts. Without this guard, `Bootstrap.run()` re-inserts 5 vendors, 10 customers, 200 sales orders, 150 purchase orders, etc. on every boot — duplicates pile up and dashboard KPIs drift.

`vendorRepository.count()` is the simplest fingerprint: if vendors exist the demo run already happened, so skip.

## Test plan
- [x] `git rebase main` — clean, no conflicts.
- [x] `./mvnw compile` — clean.
- [ ] (Reviewer) `rm -rf ./data && ./mvnw spring-boot:run` → seeds and prints the `Customers: 10 / Vendors: 5 / ...` summary.
- [ ] (Reviewer) Restart (no rm) → no Bootstrap output past `seedUsers()`; counts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)