### PR TITLE
feat(search): global topbar search (Phase 2.4)

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Controllers/SearchController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/SearchController.java
@@ -1,0 +1,65 @@
+package com.example.warehouseManagement.Controllers;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.example.warehouseManagement.Domains.Customer;
+import com.example.warehouseManagement.Domains.Item;
+import com.example.warehouseManagement.Domains.Vendor;
+import com.example.warehouseManagement.Repositories.CustomerRepository;
+import com.example.warehouseManagement.Repositories.ItemRepository;
+import com.example.warehouseManagement.Repositories.VendorRepository;
+
+/**
+ * Global search backed by case-insensitive LIKE matches across the three
+ * "directory" entities. Hit from the topbar form; returns a unified results page.
+ */
+@Controller
+@RequestMapping("/search")
+public class SearchController {
+
+    private static final int PER_CATEGORY_LIMIT = 10;
+
+    private final ItemRepository itemRepository;
+    private final CustomerRepository customerRepository;
+    private final VendorRepository vendorRepository;
+
+    public SearchController(ItemRepository itemRepository,
+                            CustomerRepository customerRepository,
+                            VendorRepository vendorRepository) {
+        this.itemRepository = itemRepository;
+        this.customerRepository = customerRepository;
+        this.vendorRepository = vendorRepository;
+    }
+
+    @GetMapping
+    public String search(@RequestParam(name = "q", required = false) String query, Model model) {
+        String trimmed = query == null ? "" : query.trim();
+        model.addAttribute("title", "Search");
+        model.addAttribute("query", trimmed);
+
+        if (trimmed.isEmpty()) {
+            model.addAttribute("items", List.of());
+            model.addAttribute("customers", List.of());
+            model.addAttribute("vendors", List.of());
+            return "search/results";
+        }
+
+        Pageable cap = PageRequest.of(0, PER_CATEGORY_LIMIT);
+        List<Item> items = itemRepository.findByDescriptionContainingIgnoreCase(trimmed, cap);
+        List<Customer> customers = customerRepository.findByNameContainingIgnoreCase(trimmed, cap);
+        List<Vendor> vendors = vendorRepository.findByNameContainingIgnoreCase(trimmed, cap);
+
+        model.addAttribute("items", items);
+        model.addAttribute("customers", customers);
+        model.addAttribute("vendors", vendors);
+        return "search/results";
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Repositories/CustomerRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/CustomerRepository.java
@@ -1,9 +1,17 @@
 package com.example.warehouseManagement.Repositories;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
 import com.example.warehouseManagement.Domains.Customer;
 
 public interface CustomerRepository extends CrudRepository<Customer, Long>{
-    
+
+    /**
+     * Case-insensitive LIKE search on name, capped by Pageable.
+     * Used by the global search bar.
+     */
+    List<Customer> findByNameContainingIgnoreCase(String name, Pageable pageable);
 }

--- a/src/main/java/com/example/warehouseManagement/Repositories/ItemRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/ItemRepository.java
@@ -2,6 +2,7 @@ package com.example.warehouseManagement.Repositories;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
 import com.example.warehouseManagement.Domains.Item;
@@ -16,5 +17,10 @@ public interface ItemRepository extends CrudRepository<Item, Long>{
      * @return
      */
     List<Item> findByVendor(Vendor vendor);
-    
+
+    /**
+     * Case-insensitive LIKE search on description, capped by Pageable.
+     * Used by the global search bar.
+     */
+    List<Item> findByDescriptionContainingIgnoreCase(String description, Pageable pageable);
 }

--- a/src/main/java/com/example/warehouseManagement/Repositories/VendorRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/VendorRepository.java
@@ -1,9 +1,17 @@
 package com.example.warehouseManagement.Repositories;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
 import com.example.warehouseManagement.Domains.Vendor;
 
 public interface VendorRepository extends CrudRepository<Vendor, Long>{
-    
+
+    /**
+     * Case-insensitive LIKE search on name, capped by Pageable.
+     * Used by the global search bar.
+     */
+    List<Vendor> findByNameContainingIgnoreCase(String name, Pageable pageable);
 }

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -165,6 +165,12 @@
             <i class="bi bi-list"></i>
         </button>
         <h1 class="h5 mb-0" th:text="${title} ?: 'Warehouse'">Dashboard</h1>
+        <form th:action="@{/search}" method="get" class="mx-3 d-none d-md-block" sec:authorize="isAuthenticated()" role="search">
+            <div class="input-group input-group-sm">
+                <span class="input-group-text bg-body-tertiary border-end-0"><i class="bi bi-search"></i></span>
+                <input type="search" class="form-control border-start-0" name="q" placeholder="Search items, customers, vendors..." style="min-width: 16rem;">
+            </div>
+        </form>
         <div class="ms-auto d-flex align-items-center gap-3" sec:authorize="isAuthenticated()">
             <span class="text-muted small d-none d-sm-inline">
                 <i class="bi bi-person-circle me-1"></i>

--- a/src/main/resources/templates/search/results.html
+++ b/src/main/resources/templates/search/results.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<div th:insert="~{fragments/header :: header}"></div>
+<div th:insert="~{fragments/navbar :: navbar}"></div>
+
+<div class="container-fluid px-4 py-3">
+    <h1 class="my-3">
+        Search results
+        <small class="text-muted" th:if="${!#strings.isEmpty(query)}" th:text="|for &quot;${query}&quot;|"></small>
+    </h1>
+
+    <div th:if="${#strings.isEmpty(query)}" class="alert alert-info">
+        Type a term into the search box at the top to find items, customers, or vendors.
+    </div>
+
+    <!-- ITEMS -->
+    <div class="card shadow-sm mb-3" th:if="${!#strings.isEmpty(query)}">
+        <div class="card-body">
+            <h5 class="card-title">
+                <i class="bi bi-box me-1"></i>Items
+                <span class="text-muted small" th:text="|(${items.size()})|"></span>
+            </h5>
+            <div th:if="${items.isEmpty()}" class="text-muted small">No matching items.</div>
+            <table th:unless="${items.isEmpty()}" class="table table-sm align-middle mb-0">
+                <thead><tr><th>SKU</th><th>Description</th><th>Vendor</th><th></th></tr></thead>
+                <tbody>
+                <tr th:each="item : ${items}">
+                    <td th:text="${item.sku}">100</td>
+                    <td th:text="${item.description}">Widget</td>
+                    <td th:text="${item.vendor != null} ? ${item.vendor.name} : ''">Acme</td>
+                    <td><a th:href="@{|/items/${item.id}|}" class="btn btn-outline-secondary btn-sm">Details</a></td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- CUSTOMERS -->
+    <div class="card shadow-sm mb-3" th:if="${!#strings.isEmpty(query)}">
+        <div class="card-body">
+            <h5 class="card-title">
+                <i class="bi bi-people me-1"></i>Customers
+                <span class="text-muted small" th:text="|(${customers.size()})|"></span>
+            </h5>
+            <div th:if="${customers.isEmpty()}" class="text-muted small">No matching customers.</div>
+            <table th:unless="${customers.isEmpty()}" class="table table-sm align-middle mb-0">
+                <thead><tr><th>Name</th><th>City</th><th>State</th><th></th></tr></thead>
+                <tbody>
+                <tr th:each="c : ${customers}">
+                    <td th:text="${c.name}">Bob</td>
+                    <td th:text="${c.city}">Jersey City</td>
+                    <td th:text="${c.state}">NJ</td>
+                    <td><a th:href="@{|/customers/${c.id}|}" class="btn btn-outline-secondary btn-sm">Details</a></td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- VENDORS -->
+    <div class="card shadow-sm mb-3" th:if="${!#strings.isEmpty(query)}">
+        <div class="card-body">
+            <h5 class="card-title">
+                <i class="bi bi-truck me-1"></i>Vendors
+                <span class="text-muted small" th:text="|(${vendors.size()})|"></span>
+            </h5>
+            <div th:if="${vendors.isEmpty()}" class="text-muted small">No matching vendors.</div>
+            <table th:unless="${vendors.isEmpty()}" class="table table-sm align-middle mb-0">
+                <thead><tr><th>Name</th><th>City</th><th>State</th><th></th></tr></thead>
+                <tbody>
+                <tr th:each="v : ${vendors}">
+                    <td th:text="${v.name}">Acme</td>
+                    <td th:text="${v.city}">Boise</td>
+                    <td th:text="${v.state}">ID</td>
+                    <td><a th:href="@{|/vendors/${v.id}|}" class="btn btn-outline-secondary btn-sm">Details</a></td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div th:insert="~{fragments/footer :: footer}"></div>
+</html>


### PR DESCRIPTION
## Summary
Adds an authenticated-only search box in the topbar that hits a new `GET /search?q=...` endpoint and renders matched **items / customers / vendors** on a unified results page.

## What's new

| Piece | Role |
|---|---|
| `SearchController` | `@GetMapping(\"/search\")` — trims `q`, caps each category at 10 via `PageRequest.of(0, 10)`, hands three lists + the query string to the model. Empty `q` renders an \"enter a term\" hint. |
| `templates/search/results.html` | Three Bootstrap cards (Items / Customers / Vendors), each a small table with Details buttons. Empty categories render \"No matching …\" inline. |
| Search input in `templates/fragments/navbar.html` | `<form action=\"/search\" method=\"get\">` between the title and the user info, hidden below `md` to keep mobile clean. `sec:authorize=\"isAuthenticated()\"` so the box only appears when logged in. |

## Repositories
Three Spring Data derived queries — no native SQL needed:
- `ItemRepository.findByDescriptionContainingIgnoreCase(String, Pageable)`
- `CustomerRepository.findByNameContainingIgnoreCase(String, Pageable)`
- `VendorRepository.findByNameContainingIgnoreCase(String, Pageable)`

## Test plan
- [x] `./mvnw test` — 32/32 passing.
- [x] Authenticated `GET /search?q=mac` — 4 MacBook items rendered with Apple Inc. vendor; Customers + Vendors cards say \"No matching\".
- [x] `GET /search?q=Carter` — three empty-state cards.
- [x] `GET /search` (no q) — info banner only.
- [x] Topbar form: `input[name=\"q\"]` + Enter submits to `/search?q=...`.
- [ ] (Reviewer) Try a term that hits all three categories (\"a\" returns lots) and confirm results page paints.

## Out of scope
- Sort/paginate within results (10/category cap is the simplification; full pagination would mean three separate pages or one unified mixed feed — bigger UX call).
- Searching SKU as an integer (current query is description-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)