### PR TITLE
fix(search): restore lost Pageable import and CustomerRepository search method

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Repositories/CustomerRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/CustomerRepository.java
@@ -1,9 +1,17 @@
 package com.example.warehouseManagement.Repositories;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.warehouseManagement.Domains.Customer;
 
 public interface CustomerRepository extends JpaRepository<Customer, Long>{
 
+    /**
+     * Case-insensitive LIKE search on name, capped by Pageable.
+     * Used by the global search bar.
+     */
+    List<Customer> findByNameContainingIgnoreCase(String name, Pageable pageable);
 }

--- a/src/main/java/com/example/warehouseManagement/Repositories/ItemRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/ItemRepository.java
@@ -2,6 +2,7 @@ package com.example.warehouseManagement.Repositories;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.warehouseManagement.Domains.Item;


### PR DESCRIPTION
## Summary
Build-fix for fallout from #15 (pagination) and #16 (search) landing on main back-to-back. Two files lost pieces of #16 during the merge:

- **`ItemRepository.java`** — still declared `findByDescriptionContainingIgnoreCase(..., Pageable pageable)` but the `import org.springframework.data.domain.Pageable;` got dropped when #15's import rewrite landed on top. Result: `Pageable cannot be resolved to a type`.
- **`CustomerRepository.java`** — lost **both** the `Pageable` import **and** the entire `findByNameContainingIgnoreCase` method. #15 rewrote this file to extend `JpaRepository`; then #16's additions were overwritten in the merge. `SearchController.search()` calls this method directly, so without it the project fails to compile.

`VendorRepository` was net-new in #16 (no preexisting content to conflict with) and survived intact.

## Diff
```java
// ItemRepository.java — add the missing import
import org.springframework.data.domain.Pageable;

// CustomerRepository.java — restore imports + method
import java.util.List;
import org.springframework.data.domain.Pageable;
...
List<Customer> findByNameContainingIgnoreCase(String name, Pageable pageable);
```

## Test plan
- [x] `./mvnw compile` — clean.
- [x] `./mvnw test` — 32/32 passing.
- [ ] (Reviewer) Boot and try `/search?q=customer-name` — expect Customer hits to show up again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)