### PR TITLE
fix(orders): wire /pending list pages to the paginated entity API

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Controllers/PurchaseOrderController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/PurchaseOrderController.java
@@ -154,13 +154,11 @@ public class PurchaseOrderController {
      * @return the name of the view to render
      */
     @GetMapping(PENDING_PURCHASE_ORDER_PATH)
-    public String getAllPendingPurchaseOrders(Model model) {
-        // TODO: -> Add pagination (25 records per page)
-        // Add the title, customers, and sales orders to the model.
+    public String getAllPendingPurchaseOrders(@PageableDefault(size = 25, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
+                                              Model model) {
         model.addAttribute("title", "Purchase Orders");
         model.addAttribute("vendors", vendorService.findAll());
-        model.addAttribute("purchaseOrders", purchaseOrderService.findAllPendingPurchaseOrder());
-        // Return the name of the view to render.
+        model.addAttribute("page", purchaseOrderService.findPendingPage(pageable));
         return "purchaseOrders/purchaseOrders";
     }
 

--- a/src/main/java/com/example/warehouseManagement/Controllers/SalesOrderController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/SalesOrderController.java
@@ -159,13 +159,11 @@ public class SalesOrderController {
      * @return the name of the view to render
      */
     @GetMapping(PENDING_SALES_ORDER_PATH)
-    public String getAllPendingSalesOrders(Model model) {
-        // TODO: -> Add pagination (25 records per page)
-        // Add the title, customers, and sales orders to the model.
+    public String getAllPendingSalesOrders(@PageableDefault(size = 25, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
+                                           Model model) {
         model.addAttribute("title", "Sales Orders");
         model.addAttribute("customers", customerService.findAll());
-        model.addAttribute("salesOrders", salesOrderService.findAllPendingOrders());
-        // Return the name of the view to render.
+        model.addAttribute("page", salesOrderService.findPendingPage(pageable));
         return "salesOrders/salesOrders";
     }
 

--- a/src/main/java/com/example/warehouseManagement/Repositories/PurchaseOrderRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/PurchaseOrderRepository.java
@@ -3,11 +3,14 @@ package com.example.warehouseManagement.Repositories;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.example.warehouseManagement.Domains.PurchaseOrder;
+import com.example.warehouseManagement.Domains.PurchaseOrder.PoStatus;
 import com.example.warehouseManagement.Domains.DTOs.AgingPoDto;
 import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
 import com.example.warehouseManagement.Domains.DTOs.PoStatusBucketDto;
@@ -16,6 +19,12 @@ import com.example.warehouseManagement.Domains.DTOs.VendorSpendDto;
 
 
 public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Long>{
+
+    /**
+     * Paginated lookup by status — used by /purchase-orders/pending.
+     */
+    Page<PurchaseOrder> findByStatus(PoStatus status, Pageable pageable);
+
     /**
      * Return a Purchase Order that matches the given purchase order number
      * @param purchaseOrderNumber

--- a/src/main/java/com/example/warehouseManagement/Repositories/SalesOrderRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/SalesOrderRepository.java
@@ -2,12 +2,15 @@ package com.example.warehouseManagement.Repositories;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.example.warehouseManagement.Domains.Customer;
 import com.example.warehouseManagement.Domains.SalesOrder;
+import com.example.warehouseManagement.Domains.SalesOrder.SoStatus;
 import com.example.warehouseManagement.Domains.DTOs.DailySalesDto;
 import com.example.warehouseManagement.Domains.DTOs.MonthlySalesDto;
 import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
@@ -16,13 +19,18 @@ import com.example.warehouseManagement.Domains.DTOs.SalesOrderDto;
 
 
 public interface SalesOrderRepository extends JpaRepository<SalesOrder, Long>{
-    
+
     /**
      * Returns a list of sales order by a customer
      * @param customer
      * @return
      */
     public List<SalesOrder> findByCustomer(Customer customer);
+
+    /**
+     * Paginated lookup by status — used by /sales-orders/pending.
+     */
+    Page<SalesOrder> findByStatus(SoStatus status, Pageable pageable);
     /**
      * Returns a list of the sales order with its total amount by a customer
      * @param customer

--- a/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderService.java
@@ -26,6 +26,10 @@ public interface PurchaseOrderService {
      */
     public Page<PurchaseOrder> findAll(Pageable pageable);
     /**
+     * Paginated IN_TRANSIT purchase orders — used by /purchase-orders/pending.
+     */
+    public Page<PurchaseOrder> findPendingPage(Pageable pageable);
+    /**
      * Returns a purchase order by a given id
      * @param id
      * @return

--- a/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderServiceImpl.java
@@ -65,6 +65,11 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
         return purchaseOrderRepository.findAll(pageable);
     }
 
+    @Override
+    public Page<PurchaseOrder> findPendingPage(Pageable pageable) {
+        return purchaseOrderRepository.findByStatus(PoStatus.IN_TRANSIT, pageable);
+    }
+
     /**
      * Returns a purchase order that matches the given id
      */

--- a/src/main/java/com/example/warehouseManagement/Services/SalesOrderService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/SalesOrderService.java
@@ -44,6 +44,10 @@ public interface SalesOrderService {
      */
     public Page<SalesOrder> findAll(Pageable pageable);
     /**
+     * Paginated PENDING sales orders — used by /sales-orders/pending.
+     */
+    public Page<SalesOrder> findPendingPage(Pageable pageable);
+    /**
      * Returns a list of all the sales order placed by a customer in the dba by a given customer id
      * @param customerId
      * @return list of sales order

--- a/src/main/java/com/example/warehouseManagement/Services/SalesOrderServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/SalesOrderServiceImpl.java
@@ -74,6 +74,11 @@ public class SalesOrderServiceImpl implements SalesOrderService {
     }
 
     @Override
+    public Page<SalesOrder> findPendingPage(Pageable pageable) {
+        return salesOrderRepository.findByStatus(SoStatus.PENDING, pageable);
+    }
+
+    @Override
     public List<SalesOrderDto> findAllByCustomer(Long customerId) {
         return salesOrderRepository.findAllByCustomer(customerId);
     }


### PR DESCRIPTION
## Summary
`/sales-orders/pending` and `/purchase-orders/pending` threw a template error because the controllers still used the old DTO finders and pushed `salesOrders` / `purchaseOrders` onto the model — but since Phase 2.3 the shared list templates iterate `\${page.content}`.

```
Property or field 'content' cannot be found on null
(template: \"salesOrders/salesOrders\" - line 65, col 17)
```

## Fix

| Layer | Change |
|---|---|
| `SalesOrderRepository` | new `Page<SalesOrder> findByStatus(SoStatus, Pageable)` |
| `PurchaseOrderRepository` | new `Page<PurchaseOrder> findByStatus(PoStatus, Pageable)` |
| `SalesOrderService(Impl)` | new `Page<SalesOrder> findPendingPage(Pageable)` → `findByStatus(PENDING, ...)` |
| `PurchaseOrderService(Impl)` | new `Page<PurchaseOrder> findPendingPage(Pageable)` → `findByStatus(IN_TRANSIT, ...)` |
| `SalesOrderController.getAllPendingSalesOrders` | takes `@PageableDefault(size=25, sort=\"date\", direction=DESC)`, sets `page` model attribute |
| `PurchaseOrderController.getAllPendingPurchaseOrders` | same |

\"Pending\" matches the old native-query semantics: SO `status = 0` (PENDING) and PO `status = 0` (IN_TRANSIT), not the partially-shipped/received bucket. If you want the partial buckets included too, that's a one-liner — `findByStatusIn(...)` — happy to follow up.

## Note on the framing

The user reported \"functions that are not defined but called in the Controller class\" on `SalesOrder`, `SalesOrderLine`, `PurchaseOrder`, `PurchaseOrderLine`. I audited every getter/method reference in `templates/salesOrders/**` and `templates/purchaseOrders/**` against those entities — **nothing is missing**. `SalesOrder.getTotal()`, `PurchaseOrder.getTotal()`, and the `*Line.getSubtotal()` methods exist and are correctly mapped from Thymeleaf's `\${x.total}` / `\${x.subtotal}` property syntax. The real bug was the wrong model attribute name, not entity methods.

## Test plan
- [x] `./mvnw test` — 32/32 passing.
- [x] Auth'd GET on `/sales-orders/pending` → 200, rows all PENDING.
- [x] Auth'd GET on `/purchase-orders/pending` → 200.
- [ ] (Reviewer) Click \"Pending\" under Sales orders + Purchase orders in the sidebar — confirm both render with the standard pagination strip and sortable headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)