### PR TITLE
feat(search): Oracle-style advanced search modal for purchase orders

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Controllers/GoodsReceiptNoteController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/GoodsReceiptNoteController.java
@@ -68,10 +68,20 @@ public class GoodsReceiptNoteController {
     }
 
     @GetMapping(SEARCH_PURCHASE_ORDER_PATH)
-    public String searchPurchaseOrder(@ModelAttribute PurchaseOrderNumberDto purchaseOrderNumberDto, Model model) {
+    public String searchPurchaseOrder(@ModelAttribute("criteria") com.example.warehouseManagement.Domains.DTOs.AdvancedPoSearchCriteria criteria,
+                                      @org.springframework.data.web.PageableDefault(size = 25,
+                                              sort = "date",
+                                              direction = org.springframework.data.domain.Sort.Direction.DESC)
+                                              org.springframework.data.domain.Pageable pageable,
+                                      Model model) {
         model.addAttribute("purchaseOrderNumberDto", new PurchaseOrderNumberDto());
         model.addAttribute("title", "Search Purchase Order");
         model.addAttribute("purchaseOrders", purchaseOrderService.findAllPendingPurchaseOrder());
+        model.addAttribute("textModes", com.example.warehouseManagement.Domains.DTOs.AdvancedPoSearchCriteria.TextMode.values());
+        model.addAttribute("statuses", com.example.warehouseManagement.Domains.PurchaseOrder.PoStatus.values());
+        if (criteria.isActive()) {
+            model.addAttribute("advancedResults", purchaseOrderService.findAdvanced(criteria, pageable));
+        }
         return "goodsReceiptNotes/searchPurchaseOrder";
     }
 

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedPoSearchCriteria.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedPoSearchCriteria.java
@@ -1,0 +1,52 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.example.warehouseManagement.Domains.PurchaseOrder.PoStatus;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Filters bound from the Advanced Search modal on /goods-receipt-notes/search-purchase-order.
+ * Every field is optional — null/blank means "ignore this filter" so a service call with
+ * an all-blank criteria returns everything (capped by Pageable).
+ */
+@Data
+@NoArgsConstructor
+public class AdvancedPoSearchCriteria {
+
+    public enum TextMode {
+        EQUALS,
+        STARTS_WITH,
+        CONTAINS
+    }
+
+    /** PO id as text — supports partial matches via {@link #idMode}. */
+    private String id;
+    private TextMode idMode = TextMode.STARTS_WITH;
+
+    /** Vendor name match against PurchaseOrder.vendor.name. */
+    private String vendor;
+    private TextMode vendorMode = TextMode.CONTAINS;
+
+    /** Inclusive date range on PurchaseOrder.date. */
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate dateFrom;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate dateTo;
+
+    /** Optional status. Null means "any status". */
+    private PoStatus status;
+
+    /** True when the user actually submitted the advanced form (any field present). */
+    public boolean isActive() {
+        return (id != null && !id.isBlank())
+                || (vendor != null && !vendor.isBlank())
+                || dateFrom != null
+                || dateTo != null
+                || status != null;
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Repositories/PurchaseOrderRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/PurchaseOrderRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,7 +19,9 @@ import com.example.warehouseManagement.Domains.DTOs.PurchaseOrderDto;
 import com.example.warehouseManagement.Domains.DTOs.VendorSpendDto;
 
 
-public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Long>{
+public interface PurchaseOrderRepository
+        extends JpaRepository<PurchaseOrder, Long>,
+                JpaSpecificationExecutor<PurchaseOrder> {
 
     /**
      * Paginated lookup by status — used by /purchase-orders/pending.

--- a/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderService.java
@@ -29,6 +29,14 @@ public interface PurchaseOrderService {
      * Paginated IN_TRANSIT purchase orders — used by /purchase-orders/pending.
      */
     public Page<PurchaseOrder> findPendingPage(Pageable pageable);
+
+    /**
+     * Advanced search — runs the dynamic Specification built from the supplied
+     * criteria. Returns an empty page if the criteria has no filters set.
+     */
+    public Page<PurchaseOrder> findAdvanced(
+            com.example.warehouseManagement.Domains.DTOs.AdvancedPoSearchCriteria criteria,
+            Pageable pageable);
     /**
      * Returns a purchase order by a given id
      * @param id

--- a/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderServiceImpl.java
@@ -1,10 +1,12 @@
 package com.example.warehouseManagement.Services;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,11 +17,15 @@ import com.example.warehouseManagement.Domains.Item;
 import com.example.warehouseManagement.Domains.PurchaseOrder;
 import com.example.warehouseManagement.Domains.PurchaseOrder.PoStatus;
 import com.example.warehouseManagement.Domains.PurchaseOrderLine;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedPoSearchCriteria;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedPoSearchCriteria.TextMode;
 import com.example.warehouseManagement.Domains.DTOs.AgingPoDto;
 import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
 import com.example.warehouseManagement.Domains.DTOs.PoStatusBucketDto;
 import com.example.warehouseManagement.Domains.DTOs.PurchaseOrderDto;
 import com.example.warehouseManagement.Domains.DTOs.VendorSpendDto;
+
+import jakarta.persistence.criteria.Predicate;
 import com.example.warehouseManagement.Domains.Exceptions.PurchaseOrderNotFoundException;
 import com.example.warehouseManagement.Domains.Exceptions.ReceivedOrderModificationException;
 import com.example.warehouseManagement.Repositories.GoodsReceiptNoteLineRepository;
@@ -68,6 +74,62 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
     @Override
     public Page<PurchaseOrder> findPendingPage(Pageable pageable) {
         return purchaseOrderRepository.findByStatus(PoStatus.IN_TRANSIT, pageable);
+    }
+
+    @Override
+    public Page<PurchaseOrder> findAdvanced(AdvancedPoSearchCriteria criteria, Pageable pageable) {
+        return purchaseOrderRepository.findAll(buildSpec(criteria), pageable);
+    }
+
+    /**
+     * AND-combine every populated filter. Empty / null fields drop out.
+     */
+    private static Specification<PurchaseOrder> buildSpec(AdvancedPoSearchCriteria c) {
+        return (root, query, cb) -> {
+            List<Predicate> ps = new ArrayList<>();
+
+            if (c.getId() != null && !c.getId().isBlank()) {
+                String idStr = c.getId().trim();
+                TextMode mode = c.getIdMode() == null ? TextMode.STARTS_WITH : c.getIdMode();
+                if (mode == TextMode.EQUALS) {
+                    // Exact equality — parse as Long so we still hit the indexed id column.
+                    try {
+                        ps.add(cb.equal(root.get("id"), Long.parseLong(idStr)));
+                    } catch (NumberFormatException ignored) {
+                        ps.add(cb.disjunction()); // un-parseable id → no match
+                    }
+                } else {
+                    // Partial match — cast id to text and LIKE against it.
+                    var idText = root.<Long>get("id").as(String.class);
+                    String pattern = (mode == TextMode.STARTS_WITH)
+                            ? idStr + "%"
+                            : "%" + idStr + "%";
+                    ps.add(cb.like(idText, pattern));
+                }
+            }
+
+            if (c.getVendor() != null && !c.getVendor().isBlank()) {
+                String v = c.getVendor().trim().toLowerCase();
+                var vendorName = cb.lower(root.get("vendor").get("name"));
+                switch (c.getVendorMode() == null ? TextMode.CONTAINS : c.getVendorMode()) {
+                    case EQUALS      -> ps.add(cb.equal(vendorName, v));
+                    case STARTS_WITH -> ps.add(cb.like(vendorName, v + "%"));
+                    case CONTAINS    -> ps.add(cb.like(vendorName, "%" + v + "%"));
+                }
+            }
+
+            if (c.getDateFrom() != null) {
+                ps.add(cb.greaterThanOrEqualTo(root.get("date"), c.getDateFrom()));
+            }
+            if (c.getDateTo() != null) {
+                ps.add(cb.lessThanOrEqualTo(root.get("date"), c.getDateTo()));
+            }
+            if (c.getStatus() != null) {
+                ps.add(cb.equal(root.get("status"), c.getStatus()));
+            }
+
+            return ps.isEmpty() ? cb.conjunction() : cb.and(ps.toArray(Predicate[]::new));
+        };
     }
 
     /**

--- a/src/main/resources/templates/goodsReceiptNotes/searchPurchaseOrder.html
+++ b/src/main/resources/templates/goodsReceiptNotes/searchPurchaseOrder.html
@@ -29,7 +29,7 @@
             </div>
         </div>
         <h1 class="my-3 text-center">Search Purchase Order</h1>
-        <!-- Customer list as table -->
+        <!-- Quick lookup by id (autocomplete on the input). -->
         <form action="#" th:action="@{/goods-receipt-notes/search-purchase-order}" th:object="${purchaseOrderNumberDto}"
             method="post" class="row g-3 needs-validation" novalidate>
             <div class="col-12">
@@ -44,11 +44,121 @@
                     Please enter the Purchase Order Number
                 </div>
             </div>
-            <div class="col-12">
-                <button type="submit" class="btn btn-dark col-12">Search Purchase Order</button>
+            <div class="col-12 d-flex gap-2">
+                <button type="submit" class="btn btn-dark flex-grow-1">Search Purchase Order</button>
+                <button type="button" class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#advancedSearchModal">
+                    <i class="bi bi-funnel me-1"></i>Advanced
+                </button>
             </div>
         </form>
     </div>
+
+    <!-- ====== Advanced search results, shown when the modal form was submitted ====== -->
+    <div th:if="${advancedResults != null}" class="container mt-4">
+        <h2 class="h4 mb-3">
+            Advanced search results
+            <small class="text-muted" th:text="|(${advancedResults.totalElements})|"></small>
+        </h2>
+        <div th:if="${advancedResults.isEmpty()}" class="alert alert-info">No purchase orders match those filters.</div>
+        <table th:unless="${advancedResults.isEmpty()}" class="table table-sm align-middle">
+            <thead>
+                <tr>
+                    <th>Id</th>
+                    <th>Date</th>
+                    <th>Vendor</th>
+                    <th>Status</th>
+                    <th class="text-end">Total</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr th:each="po : ${advancedResults.content}">
+                    <td th:text="${po.id}">1</td>
+                    <td th:text="${#temporals.format(po.date, 'yyyy-MM-dd')}">2026-05-15</td>
+                    <td th:text="${po.vendor != null ? po.vendor.name : ''}">Acme</td>
+                    <td><span class="badge bg-secondary" th:text="${po.status.name()}">IN_TRANSIT</span></td>
+                    <td class="text-end" th:text="${#numbers.formatCurrency(po.total)}">$0</td>
+                    <td>
+                        <a th:if="${po.status.name() != 'RECEIVED'}"
+                           th:href="@{|/goods-receipt-notes/${po.id}/receive|}"
+                           class="btn btn-outline-dark btn-sm">Start receiving</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<!-- ====== Oracle-style advanced search modal ====== -->
+<div class="modal fade" id="advancedSearchModal" tabindex="-1" aria-labelledby="advancedSearchModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="advancedSearchModalLabel"><i class="bi bi-funnel me-2"></i>Advanced Search</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form th:action="@{/goods-receipt-notes/search-purchase-order}" method="get" th:object="${criteria}">
+        <div class="modal-body">
+          <p class="text-muted small mb-3">Every field is optional — leave blank to skip. Filters are AND-combined.</p>
+
+          <!-- PO id row -->
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">PO id</label>
+              <select class="form-select form-select-sm" th:field="*{idMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">starts with</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{id}" placeholder="e.g. 10">
+            </div>
+          </div>
+
+          <!-- Vendor row -->
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Vendor name</label>
+              <select class="form-select form-select-sm" th:field="*{vendorMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{vendor}" placeholder="e.g. Apple">
+            </div>
+          </div>
+
+          <!-- Date range row -->
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Date from</label>
+              <input type="date" class="form-control" th:field="*{dateFrom}">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Date to</label>
+              <input type="date" class="form-control" th:field="*{dateTo}">
+            </div>
+          </div>
+
+          <!-- Status row -->
+          <div class="row g-2 align-items-end">
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Status</label>
+              <select class="form-select" th:field="*{status}">
+                <option value="">— any —</option>
+                <option th:each="s : ${statuses}" th:value="${s}" th:text="${s.name()}">IN_TRANSIT</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-dark"><i class="bi bi-search me-1"></i>Search</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>
 
 <script>


### PR DESCRIPTION
## Summary
Adds an **Advanced** button next to the existing Search PO autocomplete that opens a Bootstrap modal with four filter rows. Submitting the modal runs a dynamic JPA Specification against `purchase_order` and renders the matches inline below the simple form.

| Filter | Operator | Maps to |
|---|---|---|
| PO id | Equals / Starts with / Contains | `id` (Long for EQUALS, `CAST(id AS VARCHAR)` LIKE for partial) |
| Vendor name | Equals / Starts with / Contains | `LOWER(vendor.name)` LIKE (case-insensitive) |
| Date from / to | (inclusive range) | `date >= :from AND date <= :to` |
| Status | (exact, or "any") | `status = :enum` |

Empty fields drop out — every filter is optional and AND-combined.

## What changed

| Layer | File | Change |
|---|---|---|
| Repository | `PurchaseOrderRepository` | now also extends `JpaSpecificationExecutor<PurchaseOrder>` |
| DTO | `AdvancedPoSearchCriteria` (new) | id/idMode, vendor/vendorMode, dateFrom/dateTo, status + `TextMode` enum |
| Service | `PurchaseOrderService.findAdvanced(...)` (new) | builds the `Specification<PurchaseOrder>` per criteria |
| Controller | `GoodsReceiptNoteController.searchPurchaseOrder` | accepts `@ModelAttribute(\"criteria\") AdvancedPoSearchCriteria` + `Pageable`; adds `advancedResults` to the model only when `criteria.isActive()` |
| Template | `goodsReceiptNotes/searchPurchaseOrder.html` | Advanced button, modal-lg form, results table with **Start receiving** action |

Autocomplete on the simple PO id input is unchanged and still wired.

## UX notes
- GET form so the URL is bookmarkable and the browser back button does the right thing.
- Each text filter has its own mode dropdown (\"contains\", \"starts with\", \"equals\") rendered from the `TextMode` enum.
- Status defaults to \"— any —\"; explicit value filters to that enum.
- The **Start receiving** action only renders for rows whose status isn't RECEIVED, mirroring the existing single-PO receive flow.

## Test plan
- [x] `./mvnw test` — 32/32 passing.
- [x] Playwright: modal opens, submit with `vendor=apple, status=IN_TRANSIT` returns 12 Apple Inc. rows.
- [x] Autocomplete on the PO id input still drops down with 10 prefix matches.
- [ ] (Reviewer) Try edge cases: PO id with non-numeric input + EQUALS mode (should match nothing, no exception); STARTS_WITH `1` (should return 1, 10, 100…); date range with only `dateFrom` set; status alone.

## Out of scope / follow-up
- The same pattern could be lifted to a shared `AdvancedSearchModal` fragment and reused on the Sales Order and Items list pages.
- Pagination/sort controls inside the modal results table — current view is the default page (size=25, sort=date,DESC) and stops there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)