### PR TITLE
chore(search): Phase 0 — TextMode lift + filter-preserving pager

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Controllers/GoodsReceiptNoteController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/GoodsReceiptNoteController.java
@@ -77,7 +77,7 @@ public class GoodsReceiptNoteController {
         model.addAttribute("purchaseOrderNumberDto", new PurchaseOrderNumberDto());
         model.addAttribute("title", "Search Purchase Order");
         model.addAttribute("purchaseOrders", purchaseOrderService.findAllPendingPurchaseOrder());
-        model.addAttribute("textModes", com.example.warehouseManagement.Domains.DTOs.AdvancedPoSearchCriteria.TextMode.values());
+        model.addAttribute("textModes", com.example.warehouseManagement.Domains.DTOs.TextMode.values());
         model.addAttribute("statuses", com.example.warehouseManagement.Domains.PurchaseOrder.PoStatus.values());
         if (criteria.isActive()) {
             model.addAttribute("advancedResults", purchaseOrderService.findAdvanced(criteria, pageable));

--- a/src/main/java/com/example/warehouseManagement/Controllers/RequestContextAdvice.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/RequestContextAdvice.java
@@ -1,0 +1,25 @@
+package com.example.warehouseManagement.Controllers;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Exposes the raw HTTP query string as a {@code currentQueryString} model
+ * attribute on every Thymeleaf view. Used by {@code fragments/pagination} to
+ * rebuild pager links while preserving any active advanced-search filters.
+ *
+ * Thymeleaf 3.1 removed the {@code #request} / {@code #httpServletRequest}
+ * implicit expression objects for security reasons; injecting the request and
+ * publishing the query string ourselves is the supported replacement.
+ */
+@ControllerAdvice
+public class RequestContextAdvice {
+
+    @ModelAttribute("currentQueryString")
+    public String currentQueryString(HttpServletRequest request) {
+        String qs = request.getQueryString();
+        return qs == null ? "" : qs;
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedPoSearchCriteria.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedPoSearchCriteria.java
@@ -18,12 +18,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class AdvancedPoSearchCriteria {
 
-    public enum TextMode {
-        EQUALS,
-        STARTS_WITH,
-        CONTAINS
-    }
-
     /** PO id as text — supports partial matches via {@link #idMode}. */
     private String id;
     private TextMode idMode = TextMode.STARTS_WITH;

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/TextMode.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/TextMode.java
@@ -1,0 +1,15 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+/**
+ * Shared text-match operator for advanced-search filters across every entity
+ * (Customer, Vendor, Item, SalesOrder, PurchaseOrder, GoodsReceiptNote, ...).
+ *
+ * Originally nested inside {@code AdvancedPoSearchCriteria} (PR #21); lifted
+ * here so the per-entity criteria DTOs don't have to import an unrelated DTO's
+ * inner type.
+ */
+public enum TextMode {
+    EQUALS,
+    STARTS_WITH,
+    CONTAINS
+}

--- a/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PurchaseOrderServiceImpl.java
@@ -18,7 +18,7 @@ import com.example.warehouseManagement.Domains.PurchaseOrder;
 import com.example.warehouseManagement.Domains.PurchaseOrder.PoStatus;
 import com.example.warehouseManagement.Domains.PurchaseOrderLine;
 import com.example.warehouseManagement.Domains.DTOs.AdvancedPoSearchCriteria;
-import com.example.warehouseManagement.Domains.DTOs.AdvancedPoSearchCriteria.TextMode;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Domains.DTOs.AgingPoDto;
 import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
 import com.example.warehouseManagement.Domains.DTOs.PoStatusBucketDto;

--- a/src/main/resources/templates/fragments/pagination.html
+++ b/src/main/resources/templates/fragments/pagination.html
@@ -5,11 +5,17 @@
   Caller passes a Spring Data Page<?> as `page` plus the base URL (path only, no query).
   Example: <div th:replace="~{fragments/pagination :: pagination(page=${page}, baseUrl='/customers')}"></div>
 
-  Preserves the current `sort` query param so paging doesn't reset the user's sort.
+  Behavior: preserves the FULL current query string when generating pager links — only
+  rewrites `page=` (and additionally `sort=` for the sortHeader fragment). So advanced-
+  search filters like ?name=foo&status=PENDING are kept intact when paginating.
 -->
 <body>
 <nav th:fragment="pagination(page, baseUrl)"
      th:if="${page != null and page.totalPages > 1}"
+     th:with="qs=${#strings.defaultString(currentQueryString, '')},
+              qsNoPage=${qs.replaceAll('(^|&)page=[^&]*', '')},
+              qsClean=${qsNoPage.replaceAll('^&', '')},
+              sep=${qsClean.isEmpty() ? '?' : ('?' + qsClean + '&')}"
      class="d-flex justify-content-between align-items-center mt-3"
      aria-label="Pagination">
     <div class="text-muted small">
@@ -21,7 +27,7 @@
         <!-- Previous -->
         <li class="page-item" th:classappend="${page.first} ? 'disabled' : ''">
             <a class="page-link"
-               th:href="@{${baseUrl}(page=${page.number - 1}, size=${page.size}, sort=${param.sort})}"
+               th:href="${baseUrl} + ${sep} + 'page=' + ${page.number - 1}"
                aria-label="Previous">&laquo;</a>
         </li>
         <!-- Numbered links: show a window of up to 5 pages around current. -->
@@ -31,13 +37,13 @@
             class="page-item"
             th:classappend="${i == page.number} ? 'active' : ''">
             <a class="page-link"
-               th:href="@{${baseUrl}(page=${i}, size=${page.size}, sort=${param.sort})}"
+               th:href="${baseUrl} + ${sep} + 'page=' + ${i}"
                th:text="${i + 1}">1</a>
         </li>
         <!-- Next -->
         <li class="page-item" th:classappend="${page.last} ? 'disabled' : ''">
             <a class="page-link"
-               th:href="@{${baseUrl}(page=${page.number + 1}, size=${page.size}, sort=${param.sort})}"
+               th:href="${baseUrl} + ${sep} + 'page=' + ${page.number + 1}"
                aria-label="Next">&raquo;</a>
         </li>
     </ul>
@@ -48,12 +54,17 @@
   Usage:
     <th th:replace="~{fragments/pagination :: sortHeader(label='Name', property='name', page=${page}, baseUrl='/customers')}"></th>
   Toggles between asc/desc on the active column. Other columns become asc on first click.
+  Preserves every active filter, resets page=0 on toggle.
 -->
-<th th:fragment="sortHeader(label, property, page, baseUrl)" scope="col">
+<th th:fragment="sortHeader(label, property, page, baseUrl)" scope="col"
+    th:with="qs=${#strings.defaultString(currentQueryString, '')},
+             qsNoPageNoSort=${qs.replaceAll('(^|&)(page|sort)=[^&]*', '')},
+             qsClean=${qsNoPageNoSort.replaceAll('^&', '')},
+             sep=${qsClean.isEmpty() ? '?' : ('?' + qsClean + '&')}">
     <a th:with="active=${page != null and page.sort.getOrderFor(property) != null},
                 isAsc=${active and page.sort.getOrderFor(property).ascending},
                 nextDir=${isAsc} ? 'desc' : 'asc'"
-       th:href="@{${baseUrl}(page=0, size=${page != null} ? ${page.size} : 25, sort=${property} + ',' + ${nextDir})}"
+       th:href="${baseUrl} + ${sep} + 'page=0&sort=' + ${property} + ',' + ${nextDir}"
        class="text-decoration-none text-reset">
         <span th:text="${label}">Label</span>
         <span th:if="${active and isAsc}">&#9650;</span>


### PR DESCRIPTION
## Summary
Shared groundwork before the six per-entity advanced-search PRs land. See `plan-the-creation-of-cosmic-snail.md` (Phase 0).

## What changed

### 1. `TextMode` lifted to top-level
- New `Domains/DTOs/TextMode.java` with `{EQUALS, STARTS_WITH, CONTAINS}`.
- `AdvancedPoSearchCriteria.java` drops the nested enum; reference resolves via package (same package — no import line).
- `PurchaseOrderServiceImpl.java` + `GoodsReceiptNoteController.java` updated to import the top-level enum.

Every future `Advanced<Entity>SearchCriteria` now references one enum without an awkward `AdvancedPoSearchCriteria.TextMode` import path.

### 2. Pagination fragment preserves arbitrary query-string filters
- `templates/fragments/pagination.html` — both `pagination(...)` and `sortHeader(...)` fragments now rebuild pager hrefs by stripping only `page=` (and additionally `sort=` for sortHeader) from the current query string, preserving everything else.
- Thymeleaf 3.1 removed the `#httpServletRequest` implicit expression utility, so I added `Controllers/RequestContextAdvice.java` — a `@ControllerAdvice` that publishes the raw query string as a `currentQueryString` model attribute on every view.
- `#strings.replaceAll` also doesn't exist in Thymeleaf 3.1's `Strings` utility, so the fragment calls `String.replaceAll` directly on the bound value.

Without this, the upcoming per-entity advanced-search filters (e.g. `?name=foo&status=PENDING`) would silently drop when the user clicked page 2.

## Test plan
- [x] `./mvnw test` — **32/32 passing**.
- [x] Playwright smoke: `/customers?size=5` → next-page href is `/customers?size=5&page=1` (previously dropped `size`).
- [x] `/customers?size=5&sort=name,asc` → page-2 href keeps both params.
- [x] `/goods-receipt-notes/search-purchase-order?vendor=Apple&status=IN_TRANSIT` still returns 200 with 12 Apple rows.

## Up next (separate PRs)
1. `feat/customer-advanced-search` — Customer (simplest)
2. `feat/item-advanced-search`
3. `feat/vendor-advanced-search` (also upgrades VendorRepository to JpaRepository)
4. `feat/sales-order-advanced-search` (first enum filter; brings the `MethodArgumentTypeMismatchException` handler)
5. `feat/purchase-order-advanced-search` (reuses the existing `AdvancedPoSearchCriteria`)
6. `feat/grn-advanced-search` (canonical `GET /goods-receipt-notes` + pending/fulfilled redirects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)