### PR TITLE
feat(search): advanced search modal on /customers (Phase 1, PR 1)

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Controllers/CustomerController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/CustomerController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.example.warehouseManagement.Domains.Customer;
 import com.example.warehouseManagement.Domains.StatePool;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedCustomerSearchCriteria;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Domains.Exceptions.CustomerNotFoundException;
 import com.example.warehouseManagement.Services.CustomerService;
 
@@ -49,10 +51,13 @@ public class CustomerController {
      * @return the name of the view to render
      */
     @GetMapping
-    public String getCustomers(@PageableDefault(size = 25, sort = "name", direction = Sort.Direction.ASC) Pageable pageable,
-                               Model model) {
-        model.addAttribute("page", customerService.findAll(pageable));
+    public String getCustomers(
+            @ModelAttribute("criteria") AdvancedCustomerSearchCriteria criteria,
+            @PageableDefault(size = 25, sort = "name", direction = Sort.Direction.ASC) Pageable pageable,
+            Model model) {
+        model.addAttribute("page", customerService.findAdvanced(criteria, pageable));
         model.addAttribute("title", "Customers");
+        model.addAttribute("textModes", TextMode.values());
         return "customers/customers";
     }
 

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedCustomerSearchCriteria.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedCustomerSearchCriteria.java
@@ -1,0 +1,38 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Filters bound from the Advanced Search modal on /customers. Every field is
+ * optional — null/blank means "ignore this filter" so a service call with an
+ * all-blank criteria returns every customer (capped by Pageable).
+ */
+@Data
+@NoArgsConstructor
+public class AdvancedCustomerSearchCriteria {
+
+    /** Customer id as text — supports partial matches via {@link #idMode}. */
+    private String id;
+    private TextMode idMode = TextMode.STARTS_WITH;
+
+    /** Name match (case-insensitive). */
+    private String name;
+    private TextMode nameMode = TextMode.CONTAINS;
+
+    /** City match (case-insensitive). */
+    private String city;
+    private TextMode cityMode = TextMode.CONTAINS;
+
+    /** State match (case-insensitive). */
+    private String state;
+    private TextMode stateMode = TextMode.CONTAINS;
+
+    /** True when the user actually submitted the form with any filter set. */
+    public boolean isActive() {
+        return (id != null && !id.isBlank())
+                || (name != null && !name.isBlank())
+                || (city != null && !city.isBlank())
+                || (state != null && !state.isBlank());
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Repositories/CustomerRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/CustomerRepository.java
@@ -4,10 +4,13 @@ import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import com.example.warehouseManagement.Domains.Customer;
 
-public interface CustomerRepository extends JpaRepository<Customer, Long>{
+public interface CustomerRepository
+        extends JpaRepository<Customer, Long>,
+                JpaSpecificationExecutor<Customer> {
 
     /**
      * Case-insensitive LIKE search on name, capped by Pageable.

--- a/src/main/java/com/example/warehouseManagement/Services/CustomerService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/CustomerService.java
@@ -6,11 +6,18 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.example.warehouseManagement.Domains.Customer;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedCustomerSearchCriteria;
 import com.example.warehouseManagement.Domains.Exceptions.CustomerNotFoundException;
 
 public interface CustomerService {
     public Iterable<Customer> findAll();
     public Page<Customer> findAll(Pageable pageable);
+    /**
+     * Advanced search — empty criteria returns every row (matches Page<Customer>
+     * shape from findAll). See AdvancedCustomerSearchCriteria.isActive() for
+     * "did the user filter?" semantics.
+     */
+    public Page<Customer> findAdvanced(AdvancedCustomerSearchCriteria criteria, Pageable pageable);
     public Optional<Customer> findById(Long id);
     public Customer updateById(Long id, Customer customer) throws CustomerNotFoundException;
     public Customer save(Customer customer);

--- a/src/main/java/com/example/warehouseManagement/Services/CustomerServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/CustomerServiceImpl.java
@@ -1,14 +1,22 @@
 package com.example.warehouseManagement.Services;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import com.example.warehouseManagement.Domains.Customer;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedCustomerSearchCriteria;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Domains.Exceptions.CustomerNotFoundException;
 import com.example.warehouseManagement.Repositories.CustomerRepository;
+
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
 
 @Service
 public class CustomerServiceImpl implements CustomerService {
@@ -28,6 +36,65 @@ public class CustomerServiceImpl implements CustomerService {
     @Override
     public Page<Customer> findAll(Pageable pageable) {
         return customerRepository.findAll(pageable);
+    }
+
+    @Override
+    public Page<Customer> findAdvanced(AdvancedCustomerSearchCriteria criteria, Pageable pageable) {
+        return customerRepository.findAll(buildSpec(criteria), pageable);
+    }
+
+    /**
+     * AND-combine every populated filter. Empty / null fields drop out;
+     * empty predicate list ⇒ cb.conjunction() so the page returns all rows.
+     */
+    private static Specification<Customer> buildSpec(AdvancedCustomerSearchCriteria c) {
+        return (root, query, cb) -> {
+            List<Predicate> ps = new ArrayList<>();
+
+            if (c.getId() != null && !c.getId().isBlank()) {
+                String idStr = c.getId().trim();
+                TextMode mode = c.getIdMode() == null ? TextMode.STARTS_WITH : c.getIdMode();
+                if (mode == TextMode.EQUALS) {
+                    try {
+                        ps.add(cb.equal(root.get("id"), Long.parseLong(idStr)));
+                    } catch (NumberFormatException ignored) {
+                        ps.add(cb.disjunction()); // un-parseable id → no match
+                    }
+                } else {
+                    Expression<String> idText = root.<Long>get("id").as(String.class);
+                    String pattern = (mode == TextMode.STARTS_WITH) ? idStr + "%" : "%" + idStr + "%";
+                    ps.add(cb.like(idText, pattern));
+                }
+            }
+
+            addTextFilter(ps, cb, root.get("name"),  c.getName(),  c.getNameMode(),  TextMode.CONTAINS);
+            addTextFilter(ps, cb, root.get("city"),  c.getCity(),  c.getCityMode(),  TextMode.CONTAINS);
+            addTextFilter(ps, cb, root.get("state"), c.getState(), c.getStateMode(), TextMode.CONTAINS);
+
+            return ps.isEmpty() ? cb.conjunction() : cb.and(ps.toArray(Predicate[]::new));
+        };
+    }
+
+    /**
+     * Append a case-insensitive predicate on a string column when the user
+     * provided a non-blank value. Defaults to {@code defaultMode} if the
+     * criteria didn't specify an explicit mode.
+     */
+    private static void addTextFilter(List<Predicate> ps,
+                                      jakarta.persistence.criteria.CriteriaBuilder cb,
+                                      jakarta.persistence.criteria.Path<String> column,
+                                      String value,
+                                      TextMode mode,
+                                      TextMode defaultMode) {
+        if (value == null || value.isBlank()) return;
+        TextMode effective = (mode == null) ? defaultMode : mode;
+        String v = value.trim().toLowerCase();
+        Expression<String> lower = cb.lower(column);
+        switch (effective) {
+            case EQUALS      -> ps.add(cb.equal(lower, v));
+            case STARTS_WITH -> ps.add(cb.like(lower, v + "%"));
+            case CONTAINS    -> ps.add(cb.like(lower, "%" + v + "%"));
+        }
     }
 
     @Override

--- a/src/main/resources/templates/customers/customers.html
+++ b/src/main/resources/templates/customers/customers.html
@@ -27,7 +27,53 @@
         </div>
     </div>
     <!-- Page headers -->
-    <h1 class="my-3">Customer List</h1>
+    <div class="d-flex justify-content-between align-items-center my-3">
+        <h1 class="m-0">Customer List</h1>
+        <a class="btn btn-dark" th:href="@{/customers/new-customer}">
+            <i class="bi bi-plus-lg me-1"></i>New customer
+        </a>
+    </div>
+
+    <!-- Simple search bar (binds to criteria.name) + Advanced button -->
+    <form th:action="@{/customers}" method="get" th:object="${criteria}" class="card shadow-sm mb-3">
+        <div class="card-body row g-2 align-items-end">
+            <div class="col-md-8">
+                <label class="form-label small mb-1">Search by name</label>
+                <input type="search" class="form-control" th:field="*{name}"
+                       placeholder="Type a customer name..."
+                       data-autocomplete-source="CUSTOMER"
+                       data-autocomplete-mode="CONTAINS"
+                       data-autocomplete-fill-on-select="true">
+                <!-- Carry mode + other criteria the user already picked. -->
+                <input type="hidden" th:field="*{nameMode}">
+                <input type="hidden" th:field="*{id}">
+                <input type="hidden" th:field="*{idMode}">
+                <input type="hidden" th:field="*{city}">
+                <input type="hidden" th:field="*{cityMode}">
+                <input type="hidden" th:field="*{state}">
+                <input type="hidden" th:field="*{stateMode}">
+            </div>
+            <div class="col-md-4 d-flex gap-2">
+                <button type="submit" class="btn btn-dark flex-grow-1">
+                    <i class="bi bi-search me-1"></i>Search
+                </button>
+                <button type="button" class="btn btn-outline-secondary"
+                        data-bs-toggle="modal" data-bs-target="#advancedSearchModal">
+                    <i class="bi bi-funnel me-1"></i>Advanced
+                </button>
+            </div>
+        </div>
+    </form>
+
+    <!-- Active filter chip + Clear-filters link -->
+    <div th:if="${criteria.isActive()}" class="d-flex justify-content-between align-items-center mb-2">
+        <span class="text-muted small"
+              th:text="|Filtered: ${page.totalElements} match(es)|">Filtered: 12 matches</span>
+        <a th:href="@{/customers}" class="btn btn-link btn-sm">
+            <i class="bi bi-x-circle me-1"></i>Clear filters
+        </a>
+    </div>
+
     <!-- Customer list as table -->
     <table class="table">
         <thead>
@@ -62,6 +108,79 @@
         </tbody>
     </table>
     <div th:replace="~{fragments/pagination :: pagination(page=${page}, baseUrl='/customers')}"></div>
+</div>
+
+<!-- ====== Advanced search modal ====== -->
+<div class="modal fade" id="advancedSearchModal" tabindex="-1" aria-labelledby="advancedSearchModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="advancedSearchModalLabel"><i class="bi bi-funnel me-2"></i>Advanced Search — Customers</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form th:action="@{/customers}" method="get" th:object="${criteria}">
+        <div class="modal-body">
+          <p class="text-muted small mb-3">Every field is optional — leave all blank to list every customer. Filters are AND-combined.</p>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Customer id</label>
+              <select class="form-select form-select-sm" th:field="*{idMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">starts with</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{id}" placeholder="e.g. 10">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Name</label>
+              <select class="form-select form-select-sm" th:field="*{nameMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{name}" placeholder="e.g. Acme">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">City</label>
+              <select class="form-select form-select-sm" th:field="*{cityMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{city}" placeholder="e.g. Boise">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">State</label>
+              <select class="form-select form-select-sm" th:field="*{stateMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{state}" placeholder="e.g. NJ">
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-dark"><i class="bi bi-search me-1"></i>Search</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>
 
 <!-- Footer fragment -->


### PR DESCRIPTION
Applies the Oracle-style Advanced Search pattern to the Customers list. Empty submit shows every customer paginated (today's behavior preserved); any filter narrows the result set.

What changed
- New AdvancedCustomerSearchCriteria DTO: id, name, city, state (each with TextMode-typed *Mode partner; defaults: id STARTS_WITH, others CONTAINS).
- CustomerRepository now also extends JpaSpecificationExecutor<Customer>.
- CustomerService(Impl).findAdvanced(criteria, pageable) — dynamic Specification. Reusable text-filter helper for case-insensitive EQUALS/STARTS_WITH/CONTAINS on string columns. Id-with-mode handles Long parse failure (EQUALS) and casts to String (STARTS_WITH / CONTAINS) per the established pattern.
- CustomerController.getCustomers now binds @ModelAttribute("criteria") AdvancedCustomerSearchCriteria, exposes textModes for the modal, and always calls findAdvanced — empty criteria returns the same Page<Customer> that the old findAll(pageable) did (Spec returns cb.conjunction()).
- customers.html: simple "Search by name" bar at top (with autocomplete from PR #20) + Advanced button → Bootstrap modal-lg form with 4 filter rows. "Filtered: X match(es)" + Clear-filters link visible when criteria.isActive(). Pagination fragment unchanged (Phase 0 #22 already preserves filter query params on pagination).

Verified
- ./mvnw test: 32/32 passing.
- Playwright smoke: /customers (empty) → all rows, paginated. Open modal, fill name=a / nameMode=CONTAINS, submit. → URL /customers?id=&idMode=STARTS_WITH&name=a&nameMode=CONTAINS&... → "Filtered: 7 match(es)" banner. → 7 rows shown: Acme, Amazon, Apple, Facebook, Microsoft, SpaceX, Tesla. → Clear-filters link returns to /customers.