### PR TITLE
feat(search): advanced search modal on /items (Phase 1, PR 2)

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Controllers/ItemController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/ItemController.java
@@ -16,7 +16,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import com.example.warehouseManagement.Domains.Item;
 import com.example.warehouseManagement.Domains.StatePool;
 import com.example.warehouseManagement.Domains.Vendor;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedItemSearchCriteria;
 import com.example.warehouseManagement.Domains.DTOs.ItemDto;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Domains.Exceptions.ItemNotFoundException;
 import com.example.warehouseManagement.Services.ItemService;
 import com.example.warehouseManagement.Services.VendorService;
@@ -57,10 +59,13 @@ public class ItemController {
      * @return the name of the view to render
      */
     @GetMapping
-    public String getItems(@PageableDefault(size = 25, sort = "sku", direction = Sort.Direction.ASC) Pageable pageable,
-                           Model model) {
-        model.addAttribute("page", itemService.findAll(pageable));
+    public String getItems(
+            @ModelAttribute("criteria") AdvancedItemSearchCriteria criteria,
+            @PageableDefault(size = 25, sort = "sku", direction = Sort.Direction.ASC) Pageable pageable,
+            Model model) {
+        model.addAttribute("page", itemService.findAdvanced(criteria, pageable));
         model.addAttribute("title", "Items");
+        model.addAttribute("textModes", TextMode.values());
         return "items/items";
     }
 

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedItemSearchCriteria.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedItemSearchCriteria.java
@@ -1,0 +1,38 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Filters bound from the Advanced Search modal on /items. Every field is
+ * optional — null/blank means "ignore this filter" so a service call with an
+ * all-blank criteria returns every item (capped by Pageable).
+ */
+@Data
+@NoArgsConstructor
+public class AdvancedItemSearchCriteria {
+
+    /** Item id as text — supports partial matches via {@link #idMode}. */
+    private String id;
+    private TextMode idMode = TextMode.STARTS_WITH;
+
+    /** Item SKU as text (the column is an int; the spec casts for partial matches). */
+    private String sku;
+    private TextMode skuMode = TextMode.STARTS_WITH;
+
+    /** Description match (case-insensitive). */
+    private String description;
+    private TextMode descriptionMode = TextMode.CONTAINS;
+
+    /** Vendor name match against Item.vendor.name (case-insensitive). */
+    private String vendor;
+    private TextMode vendorMode = TextMode.CONTAINS;
+
+    /** True when the user actually submitted the form with any filter set. */
+    public boolean isActive() {
+        return (id != null && !id.isBlank())
+                || (sku != null && !sku.isBlank())
+                || (description != null && !description.isBlank())
+                || (vendor != null && !vendor.isBlank());
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Repositories/ItemRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/ItemRepository.java
@@ -4,12 +4,15 @@ import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import com.example.warehouseManagement.Domains.Item;
 import com.example.warehouseManagement.Domains.Vendor;
 
 
-public interface ItemRepository extends JpaRepository<Item, Long>{
+public interface ItemRepository
+        extends JpaRepository<Item, Long>,
+                JpaSpecificationExecutor<Item> {
 
     /**
      * Returns a list of all the products by a vendor

--- a/src/main/java/com/example/warehouseManagement/Services/ItemService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/ItemService.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.example.warehouseManagement.Domains.Item;
 import com.example.warehouseManagement.Domains.Vendor;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedItemSearchCriteria;
 import com.example.warehouseManagement.Domains.Exceptions.ItemNotFoundException;
 
 public interface ItemService {
@@ -17,6 +18,11 @@ public interface ItemService {
      */
     public Iterable<Item> findAll();
     public Page<Item> findAll(Pageable pageable);
+    /**
+     * Advanced search — empty criteria returns every row (matches Page<Item>
+     * shape from findAll). Spec returns cb.conjunction() when nothing is set.
+     */
+    public Page<Item> findAdvanced(AdvancedItemSearchCriteria criteria, Pageable pageable);
     /**
      * Return a product given its id
      * @param id

--- a/src/main/java/com/example/warehouseManagement/Services/ItemServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/ItemServiceImpl.java
@@ -1,16 +1,25 @@
 package com.example.warehouseManagement.Services;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import com.example.warehouseManagement.Domains.Item;
 import com.example.warehouseManagement.Domains.Vendor;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedItemSearchCriteria;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Domains.Exceptions.ItemNotFoundException;
 import com.example.warehouseManagement.Repositories.ItemRepository;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
 
 @Service
 public class ItemServiceImpl implements ItemService {
@@ -32,6 +41,70 @@ public class ItemServiceImpl implements ItemService {
     @Override
     public Page<Item> findAll(Pageable pageable) {
         return itemRepository.findAll(pageable);
+    }
+
+    @Override
+    public Page<Item> findAdvanced(AdvancedItemSearchCriteria criteria, Pageable pageable) {
+        return itemRepository.findAll(buildSpec(criteria), pageable);
+    }
+
+    private static Specification<Item> buildSpec(AdvancedItemSearchCriteria c) {
+        return (root, query, cb) -> {
+            List<Predicate> ps = new ArrayList<>();
+
+            // id (Long) — EQUALS uses numeric equality; STARTS_WITH/CONTAINS cast to text.
+            if (c.getId() != null && !c.getId().isBlank()) {
+                String idStr = c.getId().trim();
+                TextMode mode = c.getIdMode() == null ? TextMode.STARTS_WITH : c.getIdMode();
+                if (mode == TextMode.EQUALS) {
+                    try {
+                        ps.add(cb.equal(root.get("id"), Long.parseLong(idStr)));
+                    } catch (NumberFormatException ignored) {
+                        ps.add(cb.disjunction());
+                    }
+                } else {
+                    Expression<String> idText = root.<Long>get("id").as(String.class);
+                    String pattern = (mode == TextMode.STARTS_WITH) ? idStr + "%" : "%" + idStr + "%";
+                    ps.add(cb.like(idText, pattern));
+                }
+            }
+
+            // sku (int) — same trick: numeric equality on EQUALS, cast-to-text on partial.
+            if (c.getSku() != null && !c.getSku().isBlank()) {
+                String skuStr = c.getSku().trim();
+                TextMode mode = c.getSkuMode() == null ? TextMode.STARTS_WITH : c.getSkuMode();
+                if (mode == TextMode.EQUALS) {
+                    try {
+                        ps.add(cb.equal(root.get("sku"), Integer.parseInt(skuStr)));
+                    } catch (NumberFormatException ignored) {
+                        ps.add(cb.disjunction());
+                    }
+                } else {
+                    Expression<String> skuText = root.<Integer>get("sku").as(String.class);
+                    String pattern = (mode == TextMode.STARTS_WITH) ? skuStr + "%" : "%" + skuStr + "%";
+                    ps.add(cb.like(skuText, pattern));
+                }
+            }
+
+            addTextFilter(ps, cb, root.get("description"), c.getDescription(), c.getDescriptionMode(), TextMode.CONTAINS);
+            addTextFilter(ps, cb, root.get("vendor").get("name"), c.getVendor(), c.getVendorMode(), TextMode.CONTAINS);
+
+            return ps.isEmpty() ? cb.conjunction() : cb.and(ps.toArray(Predicate[]::new));
+        };
+    }
+
+    private static void addTextFilter(List<Predicate> ps, CriteriaBuilder cb,
+                                      Path<String> column, String value,
+                                      TextMode mode, TextMode defaultMode) {
+        if (value == null || value.isBlank()) return;
+        TextMode effective = (mode == null) ? defaultMode : mode;
+        String v = value.trim().toLowerCase();
+        Expression<String> lower = cb.lower(column);
+        switch (effective) {
+            case EQUALS      -> ps.add(cb.equal(lower, v));
+            case STARTS_WITH -> ps.add(cb.like(lower, v + "%"));
+            case CONTAINS    -> ps.add(cb.like(lower, "%" + v + "%"));
+        }
     }
     /**
      * Return a item given its id

--- a/src/main/resources/templates/items/items.html
+++ b/src/main/resources/templates/items/items.html
@@ -27,7 +27,51 @@
         </div>
     </div>
     <!-- Page headers -->
-    <h1 class="my-3">Item List</h1>
+    <div class="d-flex justify-content-between align-items-center my-3">
+        <h1 class="m-0">Item List</h1>
+        <a class="btn btn-dark" th:href="@{/items/new-item}">
+            <i class="bi bi-plus-lg me-1"></i>New item
+        </a>
+    </div>
+
+    <!-- Simple search bar (binds to criteria.description) + Advanced button -->
+    <form th:action="@{/items}" method="get" th:object="${criteria}" class="card shadow-sm mb-3">
+        <div class="card-body row g-2 align-items-end">
+            <div class="col-md-8">
+                <label class="form-label small mb-1">Search by description</label>
+                <input type="search" class="form-control" th:field="*{description}"
+                       placeholder="Type a product description..."
+                       data-autocomplete-source="ITEM"
+                       data-autocomplete-mode="CONTAINS"
+                       data-autocomplete-fill-on-select="true">
+                <input type="hidden" th:field="*{descriptionMode}">
+                <input type="hidden" th:field="*{id}">
+                <input type="hidden" th:field="*{idMode}">
+                <input type="hidden" th:field="*{sku}">
+                <input type="hidden" th:field="*{skuMode}">
+                <input type="hidden" th:field="*{vendor}">
+                <input type="hidden" th:field="*{vendorMode}">
+            </div>
+            <div class="col-md-4 d-flex gap-2">
+                <button type="submit" class="btn btn-dark flex-grow-1">
+                    <i class="bi bi-search me-1"></i>Search
+                </button>
+                <button type="button" class="btn btn-outline-secondary"
+                        data-bs-toggle="modal" data-bs-target="#advancedSearchModal">
+                    <i class="bi bi-funnel me-1"></i>Advanced
+                </button>
+            </div>
+        </div>
+    </form>
+
+    <div th:if="${criteria.isActive()}" class="d-flex justify-content-between align-items-center mb-2">
+        <span class="text-muted small"
+              th:text="|Filtered: ${page.totalElements} match(es)|">Filtered: 12 matches</span>
+        <a th:href="@{/items}" class="btn btn-link btn-sm">
+            <i class="bi bi-x-circle me-1"></i>Clear filters
+        </a>
+    </div>
+
     <!-- Item list as table -->
     <table class="table">
         <thead>
@@ -60,6 +104,79 @@
         </tbody>
     </table>
     <div th:replace="~{fragments/pagination :: pagination(page=${page}, baseUrl='/items')}"></div>
+</div>
+
+<!-- ====== Advanced search modal ====== -->
+<div class="modal fade" id="advancedSearchModal" tabindex="-1" aria-labelledby="advancedSearchModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="advancedSearchModalLabel"><i class="bi bi-funnel me-2"></i>Advanced Search — Items</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form th:action="@{/items}" method="get" th:object="${criteria}">
+        <div class="modal-body">
+          <p class="text-muted small mb-3">Every field is optional — leave all blank to list every item. Filters are AND-combined.</p>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Item id</label>
+              <select class="form-select form-select-sm" th:field="*{idMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">starts with</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{id}" placeholder="e.g. 10">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">SKU</label>
+              <select class="form-select form-select-sm" th:field="*{skuMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">starts with</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{sku}" placeholder="e.g. 1010">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Description</label>
+              <select class="form-select form-select-sm" th:field="*{descriptionMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{description}" placeholder="e.g. MacBook">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Vendor</label>
+              <select class="form-select form-select-sm" th:field="*{vendorMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{vendor}" placeholder="e.g. Apple">
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-dark"><i class="bi bi-search me-1"></i>Search</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>
 
 <!-- Footer fragment -->


### PR DESCRIPTION
## Summary
PR 2 of the advanced-search rollout. Applies the pattern to `/items` (after `/customers` shipped in #23). Empty submit shows every row paginated; filters narrow.

## What changed

| Layer | File |
|---|---|
| DTO | `Domains/DTOs/AdvancedItemSearchCriteria.java` (new) — `id, sku, description, vendor` each with a `TextMode` partner. Defaults: id/sku `STARTS_WITH`, description/vendor `CONTAINS`. |
| Repository | `ItemRepository` adds `JpaSpecificationExecutor<Item>` |
| Service | `ItemService.findAdvanced(criteria, pageable)` + Specification `buildSpec`. **id (Long)** and **sku (int)** both use numeric equality on `EQUALS` and `root.get(...).as(String.class)` cast for partial matches; parse failure on EQUALS → `cb.disjunction()` (no hit). **description** and **vendor** join through `Item.vendor.name` with the shared case-insensitive `addTextFilter` helper. Empty predicate list ⇒ `cb.conjunction()` so empty criteria returns everything. |
| Controller | `ItemController.getItems` now binds `@ModelAttribute(\"criteria\")` and always calls `findAdvanced`; exposes `textModes` for modal. |
| Template | `items/items.html` — \"Search by description\" simple bar (with autocomplete from PR #20) + Advanced button → modal-lg with 4 filter rows. Filtered banner + Clear-filters link when `criteria.isActive()`. Pagination fragment unchanged — Phase 0 PR #22 handles filter preservation. |

## Test plan
- [x] `./mvnw test` — **32/32 passing**.
- [x] Playwright smoke:
  - `/items` (empty) → 25 rows, paginated.
  - Open modal → 4 filter rows with mode dropdowns.
  - Filter `vendor=Apple` → 8 rows (AirPods, AirPods Max, 3 MacBook Pros, MacBook Air 13, Ipad Pro, Iphone 14).
- [ ] (Reviewer) Try sku=101001 with `EQUALS` → MacBook Pro 14 only.
- [ ] (Reviewer) Try description=mac + sku=101 (both partial) → AND-combined narrows to MacBook* with sku starting 101.

## Up next
PR 3 — `feat/vendor-advanced-search` (includes the base-class upgrade `CrudRepository` → `JpaRepository`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)