### PR TITLE
feat(vendor): add advanced search modal to /vendors list

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Controllers/VendorController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/VendorController.java
@@ -2,6 +2,9 @@ package com.example.warehouseManagement.Controllers;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.example.warehouseManagement.Domains.StatePool;
 import com.example.warehouseManagement.Domains.Vendor;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedVendorSearchCriteria;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Domains.Exceptions.VendorNotFoundException;
 import com.example.warehouseManagement.Services.VendorService;
 
@@ -46,11 +51,14 @@ public class VendorController {
      * @return the name of the view to render
      */
     @GetMapping
-    public String getVendors(Model model) {
-        // Adding a list of vendors and a title attribute to the model
-        model.addAttribute("vendors", vendorService.findAll());
+    public String getVendors(
+            @ModelAttribute("criteria") AdvancedVendorSearchCriteria criteria,
+            @PageableDefault(size = 25, sort = "name", direction = Sort.Direction.ASC) Pageable pageable,
+            Model model) {
+        model.addAttribute("page", vendorService.findAdvanced(criteria, pageable));
         model.addAttribute("title", "Vendors");
-        return "vendors/vendors"; // Returning the view template name
+        model.addAttribute("textModes", TextMode.values());
+        return "vendors/vendors";
     }
 
 

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedVendorSearchCriteria.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedVendorSearchCriteria.java
@@ -1,0 +1,38 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Filters bound from the Advanced Search modal on /vendors. Every field is
+ * optional — null/blank means "ignore this filter" so a service call with an
+ * all-blank criteria returns every vendor (capped by Pageable).
+ */
+@Data
+@NoArgsConstructor
+public class AdvancedVendorSearchCriteria {
+
+    /** Vendor id as text — supports partial matches via {@link #idMode}. */
+    private String id;
+    private TextMode idMode = TextMode.STARTS_WITH;
+
+    /** Name match (case-insensitive). */
+    private String name;
+    private TextMode nameMode = TextMode.CONTAINS;
+
+    /** City match (case-insensitive). */
+    private String city;
+    private TextMode cityMode = TextMode.CONTAINS;
+
+    /** State match (case-insensitive). */
+    private String state;
+    private TextMode stateMode = TextMode.CONTAINS;
+
+    /** True when the user actually submitted the form with any filter set. */
+    public boolean isActive() {
+        return (id != null && !id.isBlank())
+                || (name != null && !name.isBlank())
+                || (city != null && !city.isBlank())
+                || (state != null && !state.isBlank());
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Repositories/VendorRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/VendorRepository.java
@@ -3,11 +3,14 @@ package com.example.warehouseManagement.Repositories;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import com.example.warehouseManagement.Domains.Vendor;
 
-public interface VendorRepository extends CrudRepository<Vendor, Long>{
+public interface VendorRepository
+        extends JpaRepository<Vendor, Long>,
+                JpaSpecificationExecutor<Vendor> {
 
     /**
      * Case-insensitive LIKE search on name, capped by Pageable.

--- a/src/main/java/com/example/warehouseManagement/Services/VendorService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/VendorService.java
@@ -2,15 +2,28 @@ package com.example.warehouseManagement.Services;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import com.example.warehouseManagement.Domains.Vendor;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedVendorSearchCriteria;
 import com.example.warehouseManagement.Domains.Exceptions.VendorNotFoundException;
 
 public interface VendorService {
     /**
-     * Returns a list of all the vendors persisted in the dba
-     * @return
+     * Iterable variant — keep for callers populating <select> dropdowns in
+     * other forms (NewItemForm, NewPurchaseOrderForm). Don't remove.
      */
     public Iterable<Vendor> findAll();
+    /**
+     * Paginated variant used by the /vendors list page.
+     */
+    public Page<Vendor> findAll(Pageable pageable);
+    /**
+     * Advanced search — empty criteria returns every row (matches Page<Vendor>
+     * shape from findAll). Spec returns cb.conjunction() when nothing is set.
+     */
+    public Page<Vendor> findAdvanced(AdvancedVendorSearchCriteria criteria, Pageable pageable);
     /**
      * Returns a vendor by a given id
      * @param id

--- a/src/main/java/com/example/warehouseManagement/Services/VendorServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/VendorServiceImpl.java
@@ -1,17 +1,29 @@
 package com.example.warehouseManagement.Services;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import com.example.warehouseManagement.Domains.Vendor;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedVendorSearchCriteria;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Domains.Exceptions.VendorNotFoundException;
 import com.example.warehouseManagement.Repositories.VendorRepository;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
 
 @Service
 public class VendorServiceImpl implements VendorService {
     private final VendorRepository vendorRepository;
-    
+
     public VendorServiceImpl(VendorRepository vendorRepository) {
         this.vendorRepository = vendorRepository;
     }
@@ -22,6 +34,58 @@ public class VendorServiceImpl implements VendorService {
     @Override
     public Iterable<Vendor> findAll() {
         return vendorRepository.findAll();
+    }
+
+    @Override
+    public Page<Vendor> findAll(Pageable pageable) {
+        return vendorRepository.findAll(pageable);
+    }
+
+    @Override
+    public Page<Vendor> findAdvanced(AdvancedVendorSearchCriteria criteria, Pageable pageable) {
+        return vendorRepository.findAll(buildSpec(criteria), pageable);
+    }
+
+    private static Specification<Vendor> buildSpec(AdvancedVendorSearchCriteria c) {
+        return (root, query, cb) -> {
+            List<Predicate> ps = new ArrayList<>();
+
+            if (c.getId() != null && !c.getId().isBlank()) {
+                String idStr = c.getId().trim();
+                TextMode mode = c.getIdMode() == null ? TextMode.STARTS_WITH : c.getIdMode();
+                if (mode == TextMode.EQUALS) {
+                    try {
+                        ps.add(cb.equal(root.get("id"), Long.parseLong(idStr)));
+                    } catch (NumberFormatException ignored) {
+                        ps.add(cb.disjunction());
+                    }
+                } else {
+                    Expression<String> idText = root.<Long>get("id").as(String.class);
+                    String pattern = (mode == TextMode.STARTS_WITH) ? idStr + "%" : "%" + idStr + "%";
+                    ps.add(cb.like(idText, pattern));
+                }
+            }
+
+            addTextFilter(ps, cb, root.get("name"),  c.getName(),  c.getNameMode(),  TextMode.CONTAINS);
+            addTextFilter(ps, cb, root.get("city"),  c.getCity(),  c.getCityMode(),  TextMode.CONTAINS);
+            addTextFilter(ps, cb, root.get("state"), c.getState(), c.getStateMode(), TextMode.CONTAINS);
+
+            return ps.isEmpty() ? cb.conjunction() : cb.and(ps.toArray(Predicate[]::new));
+        };
+    }
+
+    private static void addTextFilter(List<Predicate> ps, CriteriaBuilder cb,
+                                      Path<String> column, String value,
+                                      TextMode mode, TextMode defaultMode) {
+        if (value == null || value.isBlank()) return;
+        TextMode effective = (mode == null) ? defaultMode : mode;
+        String v = value.trim().toLowerCase();
+        Expression<String> lower = cb.lower(column);
+        switch (effective) {
+            case EQUALS      -> ps.add(cb.equal(lower, v));
+            case STARTS_WITH -> ps.add(cb.like(lower, v + "%"));
+            case CONTAINS    -> ps.add(cb.like(lower, "%" + v + "%"));
+        }
     }
 
     /**

--- a/src/main/resources/templates/vendors/vendors.html
+++ b/src/main/resources/templates/vendors/vendors.html
@@ -27,24 +27,68 @@
         </div>
     </div>
     <!-- Page headers -->
-    <h1 class="my-3">Vendor List</h1>
+    <div class="d-flex justify-content-between align-items-center my-3">
+        <h1 class="m-0">Vendor List</h1>
+        <a class="btn btn-dark" th:href="@{/vendors/new-vendor}">
+            <i class="bi bi-plus-lg me-1"></i>New vendor
+        </a>
+    </div>
+
+    <!-- Simple search bar (binds to criteria.name) + Advanced button -->
+    <form th:action="@{/vendors}" method="get" th:object="${criteria}" class="card shadow-sm mb-3">
+        <div class="card-body row g-2 align-items-end">
+            <div class="col-md-8">
+                <label class="form-label small mb-1">Search by name</label>
+                <input type="search" class="form-control" th:field="*{name}"
+                       placeholder="Type a vendor name..."
+                       data-autocomplete-source="VENDOR"
+                       data-autocomplete-mode="CONTAINS"
+                       data-autocomplete-fill-on-select="true">
+                <input type="hidden" th:field="*{nameMode}">
+                <input type="hidden" th:field="*{id}">
+                <input type="hidden" th:field="*{idMode}">
+                <input type="hidden" th:field="*{city}">
+                <input type="hidden" th:field="*{cityMode}">
+                <input type="hidden" th:field="*{state}">
+                <input type="hidden" th:field="*{stateMode}">
+            </div>
+            <div class="col-md-4 d-flex gap-2">
+                <button type="submit" class="btn btn-dark flex-grow-1">
+                    <i class="bi bi-search me-1"></i>Search
+                </button>
+                <button type="button" class="btn btn-outline-secondary"
+                        data-bs-toggle="modal" data-bs-target="#advancedSearchModal">
+                    <i class="bi bi-funnel me-1"></i>Advanced
+                </button>
+            </div>
+        </div>
+    </form>
+
+    <div th:if="${criteria.isActive()}" class="d-flex justify-content-between align-items-center mb-2">
+        <span class="text-muted small"
+              th:text="|Filtered: ${page.totalElements} match(es)|">Filtered: 3 matches</span>
+        <a th:href="@{/vendors}" class="btn btn-link btn-sm">
+            <i class="bi bi-x-circle me-1"></i>Clear filters
+        </a>
+    </div>
+
     <!-- vendor list as table -->
     <table class="table">
         <thead>
             <tr>
-                <th scope="col">Id</th>
-                <th scope="col">Name</th>
-                <th scope="col">Street</th>
-                <th scope="col">City</th>
-                <th scope="col">State</th>
-                <th scope="col">zipcode</th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='Id', property='id', page=${page}, baseUrl='/vendors')}"></th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='Name', property='name', page=${page}, baseUrl='/vendors')}"></th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='Street', property='street', page=${page}, baseUrl='/vendors')}"></th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='City', property='city', page=${page}, baseUrl='/vendors')}"></th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='State', property='state', page=${page}, baseUrl='/vendors')}"></th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='Zipcode', property='zipcode', page=${page}, baseUrl='/vendors')}"></th>
                 <th scope="col"></th>
                 <th scope="col"></th>
                 <th scope="col"></th>
             </tr>
         </thead>
         <tbody>
-            <tr th:each="vendor : ${vendors}">
+            <tr th:each="vendor : ${page.content}">
                 <th scope="row" th:text="${vendor.id}">1</th>
                 <td th:text="${vendor.name}">Mark</td>
                 <td th:text="${vendor.street}">Otto</td>
@@ -61,6 +105,80 @@
             </tr>
         </tbody>
     </table>
+    <div th:replace="~{fragments/pagination :: pagination(page=${page}, baseUrl='/vendors')}"></div>
+</div>
+
+<!-- ====== Advanced search modal ====== -->
+<div class="modal fade" id="advancedSearchModal" tabindex="-1" aria-labelledby="advancedSearchModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="advancedSearchModalLabel"><i class="bi bi-funnel me-2"></i>Advanced Search — Vendors</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form th:action="@{/vendors}" method="get" th:object="${criteria}">
+        <div class="modal-body">
+          <p class="text-muted small mb-3">Every field is optional — leave all blank to list every vendor. Filters are AND-combined.</p>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Vendor id</label>
+              <select class="form-select form-select-sm" th:field="*{idMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">starts with</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{id}" placeholder="e.g. 10">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Name</label>
+              <select class="form-select form-select-sm" th:field="*{nameMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{name}" placeholder="e.g. Apple">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">City</label>
+              <select class="form-select form-select-sm" th:field="*{cityMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{city}" placeholder="e.g. Cupertino">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">State</label>
+              <select class="form-select form-select-sm" th:field="*{stateMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{state}" placeholder="e.g. CA">
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-dark"><i class="bi bi-search me-1"></i>Search</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>
 
 <!-- Footer fragment -->


### PR DESCRIPTION
## Summary
- PR 3/6 in the Oracle-style advanced search rollout. Mirrors the recipe from PR #23 (Customer) and #24 (Item).
- New `AdvancedVendorSearchCriteria` DTO (id / name / city / state + per-field `TextMode`), `JpaSpecificationExecutor` on `VendorRepository`, `VendorService.findAdvanced` building a `Specification<Vendor>` that returns `cb.conjunction()` when no filters are set — fresh `/vendors` keeps showing every row, paginated.
- `VendorController` binds `@ModelAttribute("criteria")` + `@PageableDefault(size=25, sort="name")` and always calls `findAdvanced`. No `if (criteria.isActive())` guard — empty criteria → full list.
- `vendors.html` rewritten: iterates `${page.content}`, adds the shared sort-header + pagination fragments, a top-of-page simple search bar (binds `criteria.name`), an **Advanced** button that opens a Bootstrap modal-lg with one row per filter, and a "Filtered: N — Clear filters" affordance.
- Kept `Iterable<Vendor> findAll()` on the service interface — `NewItemForm` and `NewPurchaseOrderForm` use it to populate `<select>` dropdowns.

## Test plan
- [x] `./mvnw test` — 32 tests, all green.
- [ ] Boot + visit `/vendors` → 25 rows, page 1 of everything, just like before.
- [ ] Type a vendor name in the simple search → narrows; URL contains `?name=…&nameMode=CONTAINS`.
- [ ] Open Advanced modal → fill city + state → narrows; URL carries every filter param.
- [ ] Click page 2 with filters active → filters persist in URL.
- [ ] Click a sort header with filters active → filters persist; page resets to 0.
- [ ] Reopen Advanced after a submit → fields pre-filled with last values.
- [ ] **Clear filters** → URL becomes `/vendors`, full unfiltered list returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)