### PR TITLE
feat(sales-order): add advanced search modal to /sales-orders list

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Controllers/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.warehouseManagement.Controllers;
 
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.example.warehouseManagement.Domains.Exceptions.CustomerNotFoundException;
 import com.example.warehouseManagement.Domains.Exceptions.ItemNotFoundException;
@@ -10,6 +11,8 @@ import com.example.warehouseManagement.Domains.Exceptions.ReceivedOrderModificat
 import com.example.warehouseManagement.Domains.Exceptions.SalesOrderNotFoundException;
 import com.example.warehouseManagement.Domains.Exceptions.ShippedOrderModificationException;
 import com.example.warehouseManagement.Domains.Exceptions.VendorNotFoundException;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Centralizes the redirect-to-list-with-banner behavior that used to live as
@@ -61,5 +64,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ReceivedOrderModificationException.class)
     public String handleReceivedOrderModification() {
         return "redirect:/purchase-orders?cannotBeUpdated";
+    }
+
+    /**
+     * An invalid value bound to an enum query param on a list page
+     * (e.g. {@code /sales-orders?status=GARBAGE}) would otherwise surface as a
+     * 500. Redirect back to the same path with {@code ?invalidFilter} so the
+     * list template renders a small warning banner and shows everything.
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public String handleInvalidFilter(HttpServletRequest request) {
+        return "redirect:" + request.getRequestURI() + "?invalidFilter";
     }
 }

--- a/src/main/java/com/example/warehouseManagement/Controllers/SalesOrderController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/SalesOrderController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import com.example.warehouseManagement.Domains.SalesOrder;
 import com.example.warehouseManagement.Domains.SalesOrder.SoStatus;
 import com.example.warehouseManagement.Domains.SalesOrderLine;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedSalesOrderSearchCriteria;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Domains.Exceptions.SalesOrderNotFoundException;
 import com.example.warehouseManagement.Domains.Exceptions.ShippedOrderModificationException;
 import com.example.warehouseManagement.Services.CustomerService;
@@ -142,28 +144,35 @@ public class SalesOrderController {
      * @return the name of the view to render
      */
     @GetMapping
-    public String getAllSalesOrders(@PageableDefault(size = 25, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
-                                    Model model) {
+    public String getAllSalesOrders(
+            @ModelAttribute("criteria") AdvancedSalesOrderSearchCriteria criteria,
+            @PageableDefault(size = 25, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model) {
         model.addAttribute("title", "Sales Orders");
         model.addAttribute("customers", customerService.findAll());
-        model.addAttribute("page", salesOrderService.findAll(pageable));
+        model.addAttribute("page", salesOrderService.findAdvanced(criteria, pageable));
+        model.addAttribute("textModes", TextMode.values());
+        model.addAttribute("statuses", SoStatus.values());
         return "salesOrders/salesOrders";
     }
 
     /**
-     * GET /sales-order/pending
+     * GET /sales-orders/pending
      *
-     * Gets all sales orders.
-     *
-     * @param model a Model object to be populated with data for the view
-     * @return the name of the view to render
+     * Pending-only convenience endpoint kept for the navbar shortcut. The
+     * canonical list now supports status filtering via the Advanced modal,
+     * but this URL still works as a bookmark.
      */
     @GetMapping(PENDING_SALES_ORDER_PATH)
-    public String getAllPendingSalesOrders(@PageableDefault(size = 25, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
-                                           Model model) {
+    public String getAllPendingSalesOrders(
+            @ModelAttribute("criteria") AdvancedSalesOrderSearchCriteria criteria,
+            @PageableDefault(size = 25, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model) {
         model.addAttribute("title", "Sales Orders");
         model.addAttribute("customers", customerService.findAll());
         model.addAttribute("page", salesOrderService.findPendingPage(pageable));
+        model.addAttribute("textModes", TextMode.values());
+        model.addAttribute("statuses", SoStatus.values());
         return "salesOrders/salesOrders";
     }
 

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedSalesOrderSearchCriteria.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedSalesOrderSearchCriteria.java
@@ -1,0 +1,46 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.example.warehouseManagement.Domains.SalesOrder.SoStatus;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Filters bound from the Advanced Search modal on /sales-orders. Every field
+ * is optional — null/blank means "ignore this filter" so a service call with
+ * an all-blank criteria returns every sales order (capped by Pageable).
+ */
+@Data
+@NoArgsConstructor
+public class AdvancedSalesOrderSearchCriteria {
+
+    /** SO id as text — supports partial matches via {@link #idMode}. */
+    private String id;
+    private TextMode idMode = TextMode.STARTS_WITH;
+
+    /** Customer name match against SalesOrder.customer.name. */
+    private String customer;
+    private TextMode customerMode = TextMode.CONTAINS;
+
+    /** Inclusive date range on SalesOrder.date. */
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate dateFrom;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate dateTo;
+
+    /** Optional status. Null means "any status". */
+    private SoStatus status;
+
+    /** True when the user actually submitted the form with any filter set. */
+    public boolean isActive() {
+        return (id != null && !id.isBlank())
+                || (customer != null && !customer.isBlank())
+                || dateFrom != null
+                || dateTo != null
+                || status != null;
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Repositories/SalesOrderRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/SalesOrderRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,7 +19,9 @@ import com.example.warehouseManagement.Domains.DTOs.PendingSalesOrderDto;
 import com.example.warehouseManagement.Domains.DTOs.SalesOrderDto;
 
 
-public interface SalesOrderRepository extends JpaRepository<SalesOrder, Long>{
+public interface SalesOrderRepository
+        extends JpaRepository<SalesOrder, Long>,
+                JpaSpecificationExecutor<SalesOrder> {
 
     /**
      * Returns a list of sales order by a customer

--- a/src/main/java/com/example/warehouseManagement/Services/SalesOrderService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/SalesOrderService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import com.example.warehouseManagement.Domains.Customer;
 import com.example.warehouseManagement.Domains.LastThreeMonthsSales;
 import com.example.warehouseManagement.Domains.SalesOrder;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedSalesOrderSearchCriteria;
 import com.example.warehouseManagement.Domains.DTOs.DailySalesDto;
 import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
 import com.example.warehouseManagement.Domains.DTOs.PendingSalesOrderDto;
@@ -47,6 +48,11 @@ public interface SalesOrderService {
      * Paginated PENDING sales orders — used by /sales-orders/pending.
      */
     public Page<SalesOrder> findPendingPage(Pageable pageable);
+    /**
+     * Advanced search — empty criteria returns every row (matches Page<SalesOrder>
+     * shape from findAll). Spec returns cb.conjunction() when nothing is set.
+     */
+    public Page<SalesOrder> findAdvanced(AdvancedSalesOrderSearchCriteria criteria, Pageable pageable);
     /**
      * Returns a list of all the sales order placed by a customer in the dba by a given customer id
      * @param customerId

--- a/src/main/java/com/example/warehouseManagement/Services/SalesOrderServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/SalesOrderServiceImpl.java
@@ -1,10 +1,12 @@
 package com.example.warehouseManagement.Services;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,12 +18,16 @@ import com.example.warehouseManagement.Domains.PickingJobLine;
 import com.example.warehouseManagement.Domains.SalesOrder;
 import com.example.warehouseManagement.Domains.SalesOrder.SoStatus;
 import com.example.warehouseManagement.Domains.SalesOrderLine;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedSalesOrderSearchCriteria;
 import com.example.warehouseManagement.Domains.DTOs.DailySalesDto;
 import com.example.warehouseManagement.Domains.DTOs.OpenOrdersKpiDto;
 import com.example.warehouseManagement.Domains.DTOs.PendingSalesOrderDto;
 import com.example.warehouseManagement.Domains.DTOs.SalesOrderDto;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Domains.Exceptions.SalesOrderNotFoundException;
 import com.example.warehouseManagement.Domains.Exceptions.ShippedOrderModificationException;
+
+import jakarta.persistence.criteria.Predicate;
 import com.example.warehouseManagement.Repositories.ItemPriceRepository;
 import com.example.warehouseManagement.Repositories.ItemRepository;
 import com.example.warehouseManagement.Repositories.PickingJobLineRepository;
@@ -76,6 +82,55 @@ public class SalesOrderServiceImpl implements SalesOrderService {
     @Override
     public Page<SalesOrder> findPendingPage(Pageable pageable) {
         return salesOrderRepository.findByStatus(SoStatus.PENDING, pageable);
+    }
+
+    @Override
+    public Page<SalesOrder> findAdvanced(AdvancedSalesOrderSearchCriteria criteria, Pageable pageable) {
+        return salesOrderRepository.findAll(buildSpec(criteria), pageable);
+    }
+
+    private static Specification<SalesOrder> buildSpec(AdvancedSalesOrderSearchCriteria c) {
+        return (root, query, cb) -> {
+            List<Predicate> ps = new ArrayList<>();
+
+            if (c.getId() != null && !c.getId().isBlank()) {
+                String idStr = c.getId().trim();
+                TextMode mode = c.getIdMode() == null ? TextMode.STARTS_WITH : c.getIdMode();
+                if (mode == TextMode.EQUALS) {
+                    try {
+                        ps.add(cb.equal(root.get("id"), Long.parseLong(idStr)));
+                    } catch (NumberFormatException ignored) {
+                        ps.add(cb.disjunction());
+                    }
+                } else {
+                    var idText = root.<Long>get("id").as(String.class);
+                    String pattern = (mode == TextMode.STARTS_WITH) ? idStr + "%" : "%" + idStr + "%";
+                    ps.add(cb.like(idText, pattern));
+                }
+            }
+
+            if (c.getCustomer() != null && !c.getCustomer().isBlank()) {
+                String v = c.getCustomer().trim().toLowerCase();
+                var customerName = cb.lower(root.get("customer").get("name"));
+                switch (c.getCustomerMode() == null ? TextMode.CONTAINS : c.getCustomerMode()) {
+                    case EQUALS      -> ps.add(cb.equal(customerName, v));
+                    case STARTS_WITH -> ps.add(cb.like(customerName, v + "%"));
+                    case CONTAINS    -> ps.add(cb.like(customerName, "%" + v + "%"));
+                }
+            }
+
+            if (c.getDateFrom() != null) {
+                ps.add(cb.greaterThanOrEqualTo(root.get("date"), c.getDateFrom()));
+            }
+            if (c.getDateTo() != null) {
+                ps.add(cb.lessThanOrEqualTo(root.get("date"), c.getDateTo()));
+            }
+            if (c.getStatus() != null) {
+                ps.add(cb.equal(root.get("status"), c.getStatus()));
+            }
+
+            return ps.isEmpty() ? cb.conjunction() : cb.and(ps.toArray(Predicate[]::new));
+        };
     }
 
     @Override

--- a/src/main/resources/templates/salesOrders/salesOrders.html
+++ b/src/main/resources/templates/salesOrders/salesOrders.html
@@ -47,14 +47,66 @@
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
     </div>
+    <!-- ALERT: invalid enum query param (e.g. ?status=GARBAGE) -->
+    <div th:if="${param.invalidFilter}">
+        <div class="alert alert-warning alert-dismissible fade show mt-3" role="alert">
+            One of the filter values was not recognized — showing every sales order.
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    </div>
+
     <!-- Page headers -->
-    <h1 class="my-3" th:text="|Sales Orders|">Customer List</h1>
+    <div class="d-flex justify-content-between align-items-center my-3">
+        <h1 class="m-0" th:text="${title}">Sales Orders</h1>
+        <a class="btn btn-dark" th:href="@{/sales-orders/new-sales-order}">
+            <i class="bi bi-plus-lg me-1"></i>New sales order
+        </a>
+    </div>
+
+    <!-- Simple search bar (binds criteria.id) + Advanced button -->
+    <form th:action="@{/sales-orders}" method="get" th:object="${criteria}" class="card shadow-sm mb-3">
+        <div class="card-body row g-2 align-items-end">
+            <div class="col-md-8">
+                <label class="form-label small mb-1">Search by sales-order id</label>
+                <input type="search" class="form-control" th:field="*{id}"
+                       placeholder="Type a sales order id..."
+                       data-autocomplete-source="SALES_ORDER"
+                       data-autocomplete-mode="PREFIX"
+                       data-autocomplete-fill-on-select="true">
+                <input type="hidden" th:field="*{idMode}">
+                <input type="hidden" th:field="*{customer}">
+                <input type="hidden" th:field="*{customerMode}">
+                <input type="hidden" th:field="*{dateFrom}">
+                <input type="hidden" th:field="*{dateTo}">
+                <input type="hidden" th:field="*{status}">
+            </div>
+            <div class="col-md-4 d-flex gap-2">
+                <button type="submit" class="btn btn-dark flex-grow-1">
+                    <i class="bi bi-search me-1"></i>Search
+                </button>
+                <button type="button" class="btn btn-outline-secondary"
+                        data-bs-toggle="modal" data-bs-target="#advancedSearchModal">
+                    <i class="bi bi-funnel me-1"></i>Advanced
+                </button>
+            </div>
+        </div>
+    </form>
+
+    <div th:if="${criteria.isActive()}" class="d-flex justify-content-between align-items-center mb-2">
+        <span class="text-muted small"
+              th:text="|Filtered: ${page.totalElements} match(es)|">Filtered: 3 matches</span>
+        <a th:href="@{/sales-orders}" class="btn btn-link btn-sm">
+            <i class="bi bi-x-circle me-1"></i>Clear filters
+        </a>
+    </div>
+
     <!-- Customer list as table -->
     <table class="table">
         <thead>
             <tr>
                 <th th:replace="~{fragments/pagination :: sortHeader(label='Date', property='date', page=${page}, baseUrl='/sales-orders')}"></th>
                 <th th:replace="~{fragments/pagination :: sortHeader(label='Sales Order', property='id', page=${page}, baseUrl='/sales-orders')}"></th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='Customer', property='customer.name', page=${page}, baseUrl='/sales-orders')}"></th>
                 <th scope="col">Total</th>
                 <th th:replace="~{fragments/pagination :: sortHeader(label='Status', property='status', page=${page}, baseUrl='/sales-orders')}"></th>
                 <th scope="col"></th>
@@ -65,6 +117,7 @@
             <tr th:each="salesOrder : ${page.content}">
                 <th scope="row" th:text="|${#temporals.monthNameShort(salesOrder.date)} ${#temporals.format(salesOrder.date, ' dd, yyyy')}|">1</th>
                 <td th:text="${salesOrder.id}">1001</td>
+                <td th:text="${salesOrder.customer != null ? salesOrder.customer.name : ''}">Acme</td>
                 <td th:text="${#numbers.formatCurrency(salesOrder.total)}">$0</td>
                 <td th:text="${salesOrder.status.name()}">PENDING</td>
                 <td><a th:href="@{/sales-orders/{orderId}(orderId=${salesOrder.id})}" class="btn btn-outline-secondary">Details</a></td>
@@ -80,6 +133,74 @@
         </tbody>
     </table>
     <div th:replace="~{fragments/pagination :: pagination(page=${page}, baseUrl='/sales-orders')}"></div>
+</div>
+
+<!-- ====== Advanced search modal ====== -->
+<div class="modal fade" id="advancedSearchModal" tabindex="-1" aria-labelledby="advancedSearchModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="advancedSearchModalLabel"><i class="bi bi-funnel me-2"></i>Advanced Search — Sales Orders</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form th:action="@{/sales-orders}" method="get" th:object="${criteria}">
+        <div class="modal-body">
+          <p class="text-muted small mb-3">Every field is optional — leave all blank to list every sales order. Filters are AND-combined.</p>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">SO id</label>
+              <select class="form-select form-select-sm" th:field="*{idMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">starts with</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{id}" placeholder="e.g. 10">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Customer name</label>
+              <select class="form-select form-select-sm" th:field="*{customerMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{customer}" placeholder="e.g. Acme">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Date from</label>
+              <input type="date" class="form-control" th:field="*{dateFrom}">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Date to</label>
+              <input type="date" class="form-control" th:field="*{dateTo}">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end">
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Status</label>
+              <select class="form-select" th:field="*{status}">
+                <option value="">— any —</option>
+                <option th:each="s : ${statuses}" th:value="${s}" th:text="${s.name()}">PENDING</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-dark"><i class="bi bi-search me-1"></i>Search</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>
 
 <!-- Header fragment -->


### PR DESCRIPTION
- Add AdvancedSalesOrderSearchCriteria DTO (id, customer, status enum, date range + per-field TextMode)
- SalesOrderRepository extends JpaSpecificationExecutor
- SalesOrderService.findAdvanced + Specification buildSpec; empty criteria returns cb.conjunction() so a fresh /sales-orders lists all rows, joining customer.name and date/status when filters are set
- Wire SalesOrderController.getAllSalesOrders to bind @ModelAttribute("criteria") + @PageableDefault and call findAdvanced; publishes textModes + SoStatus.values() for the modal selects
- Rewrite salesOrders.html: simple search bar bound to criteria.id, Advanced button + Bootstrap modal-lg with id/customer/date-range/ status rows, Clear-filters chip when filters are active, new Customer sort column
- Add @ExceptionHandler(MethodArgumentTypeMismatchException) to GlobalExceptionHandler — invalid enum query params (e.g. ?status=GARBAGE) redirect back with ?invalidFilter so the list page renders a small warning instead of a 500

Mirrors PR #23 (Customer), #24 (Item), #25 (Vendor). First PR in the rollout to ship the invalid-enum handler; future PRs (PO, GRN) reuse it.