### PR TITLE
feat(purchase-order): wire advanced search modal to /purchase-orders list

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Controllers/GoodsReceiptNoteController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/GoodsReceiptNoteController.java
@@ -79,9 +79,9 @@ public class GoodsReceiptNoteController {
         model.addAttribute("purchaseOrders", purchaseOrderService.findAllPendingPurchaseOrder());
         model.addAttribute("textModes", com.example.warehouseManagement.Domains.DTOs.TextMode.values());
         model.addAttribute("statuses", com.example.warehouseManagement.Domains.PurchaseOrder.PoStatus.values());
-        if (criteria.isActive()) {
-            model.addAttribute("advancedResults", purchaseOrderService.findAdvanced(criteria, pageable));
-        }
+        // Always populate results — empty criteria → every PO, paginated. This
+        // matches the load-everything UX of the per-entity list pages.
+        model.addAttribute("advancedResults", purchaseOrderService.findAdvanced(criteria, pageable));
         return "goodsReceiptNotes/searchPurchaseOrder";
     }
 

--- a/src/main/java/com/example/warehouseManagement/Controllers/PurchaseOrderController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/PurchaseOrderController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import com.example.warehouseManagement.Domains.PurchaseOrder;
 import com.example.warehouseManagement.Domains.PurchaseOrder.PoStatus;
 import com.example.warehouseManagement.Domains.PurchaseOrderLine;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedPoSearchCriteria;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Domains.Exceptions.PurchaseOrderNotFoundException;
 import com.example.warehouseManagement.Domains.Exceptions.ReceivedOrderModificationException;
 import com.example.warehouseManagement.Services.ItemService;
@@ -137,11 +139,15 @@ public class PurchaseOrderController {
      * @return the name of the view template to render
      */
     @GetMapping
-    public String getAllPurchaseOrders(@PageableDefault(size = 25, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
-                                       Model model) {
+    public String getAllPurchaseOrders(
+            @ModelAttribute("criteria") AdvancedPoSearchCriteria criteria,
+            @PageableDefault(size = 25, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model) {
         model.addAttribute("title", "Purchase Orders");
         model.addAttribute("vendors", vendorService.findAll());
-        model.addAttribute("page", purchaseOrderService.findAll(pageable));
+        model.addAttribute("page", purchaseOrderService.findAdvanced(criteria, pageable));
+        model.addAttribute("textModes", TextMode.values());
+        model.addAttribute("statuses", PoStatus.values());
         return "purchaseOrders/purchaseOrders";
     }
 
@@ -154,11 +160,15 @@ public class PurchaseOrderController {
      * @return the name of the view to render
      */
     @GetMapping(PENDING_PURCHASE_ORDER_PATH)
-    public String getAllPendingPurchaseOrders(@PageableDefault(size = 25, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
-                                              Model model) {
+    public String getAllPendingPurchaseOrders(
+            @ModelAttribute("criteria") AdvancedPoSearchCriteria criteria,
+            @PageableDefault(size = 25, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model) {
         model.addAttribute("title", "Purchase Orders");
         model.addAttribute("vendors", vendorService.findAll());
         model.addAttribute("page", purchaseOrderService.findPendingPage(pageable));
+        model.addAttribute("textModes", TextMode.values());
+        model.addAttribute("statuses", PoStatus.values());
         return "purchaseOrders/purchaseOrders";
     }
 

--- a/src/main/resources/templates/goodsReceiptNotes/searchPurchaseOrder.html
+++ b/src/main/resources/templates/goodsReceiptNotes/searchPurchaseOrder.html
@@ -53,20 +53,27 @@
         </form>
     </div>
 
-    <!-- ====== Advanced search results, shown when the modal form was submitted ====== -->
-    <div th:if="${advancedResults != null}" class="container mt-4">
-        <h2 class="h4 mb-3">
-            Advanced search results
-            <small class="text-muted" th:text="|(${advancedResults.totalElements})|"></small>
-        </h2>
+    <!-- ====== Purchase orders — empty criteria lists every PO, paginated ====== -->
+    <div class="container mt-4">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h2 class="h4 m-0">
+                <span th:if="${criteria.isActive()}">Advanced search results</span>
+                <span th:unless="${criteria.isActive()}">Purchase orders</span>
+                <small class="text-muted" th:text="|(${advancedResults.totalElements})|"></small>
+            </h2>
+            <a th:if="${criteria.isActive()}" th:href="@{/goods-receipt-notes/search-purchase-order}"
+               class="btn btn-link btn-sm">
+                <i class="bi bi-x-circle me-1"></i>Clear filters
+            </a>
+        </div>
         <div th:if="${advancedResults.isEmpty()}" class="alert alert-info">No purchase orders match those filters.</div>
         <table th:unless="${advancedResults.isEmpty()}" class="table table-sm align-middle">
             <thead>
                 <tr>
-                    <th>Id</th>
-                    <th>Date</th>
-                    <th>Vendor</th>
-                    <th>Status</th>
+                    <th th:replace="~{fragments/pagination :: sortHeader(label='Id', property='id', page=${advancedResults}, baseUrl='/goods-receipt-notes/search-purchase-order')}"></th>
+                    <th th:replace="~{fragments/pagination :: sortHeader(label='Date', property='date', page=${advancedResults}, baseUrl='/goods-receipt-notes/search-purchase-order')}"></th>
+                    <th th:replace="~{fragments/pagination :: sortHeader(label='Vendor', property='vendor.name', page=${advancedResults}, baseUrl='/goods-receipt-notes/search-purchase-order')}"></th>
+                    <th th:replace="~{fragments/pagination :: sortHeader(label='Status', property='status', page=${advancedResults}, baseUrl='/goods-receipt-notes/search-purchase-order')}"></th>
                     <th class="text-end">Total</th>
                     <th></th>
                 </tr>
@@ -86,6 +93,7 @@
                 </tr>
             </tbody>
         </table>
+        <div th:replace="~{fragments/pagination :: pagination(page=${advancedResults}, baseUrl='/goods-receipt-notes/search-purchase-order')}"></div>
     </div>
 </div>
 

--- a/src/main/resources/templates/purchaseOrders/purchaseOrders.html
+++ b/src/main/resources/templates/purchaseOrders/purchaseOrders.html
@@ -47,14 +47,66 @@
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
     </div>
+    <!-- ALERT: invalid enum query param (e.g. ?status=GARBAGE) -->
+    <div th:if="${param.invalidFilter}">
+        <div class="alert alert-warning alert-dismissible fade show mt-3" role="alert">
+            One of the filter values was not recognized — showing every purchase order.
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    </div>
+
     <!-- Page headers -->
-    <h1 class="my-3" th:text="|Purchase Orders|">Customer List</h1>
-    <!-- Customer list as table -->
+    <div class="d-flex justify-content-between align-items-center my-3">
+        <h1 class="m-0" th:text="${title}">Purchase Orders</h1>
+        <a class="btn btn-dark" th:href="@{/purchase-orders/new-purchase-order}">
+            <i class="bi bi-plus-lg me-1"></i>New purchase order
+        </a>
+    </div>
+
+    <!-- Simple search bar (binds criteria.id) + Advanced button -->
+    <form th:action="@{/purchase-orders}" method="get" th:object="${criteria}" class="card shadow-sm mb-3">
+        <div class="card-body row g-2 align-items-end">
+            <div class="col-md-8">
+                <label class="form-label small mb-1">Search by purchase-order id</label>
+                <input type="search" class="form-control" th:field="*{id}"
+                       placeholder="Type a purchase order id..."
+                       data-autocomplete-source="PURCHASE_ORDER"
+                       data-autocomplete-mode="PREFIX"
+                       data-autocomplete-fill-on-select="true">
+                <input type="hidden" th:field="*{idMode}">
+                <input type="hidden" th:field="*{vendor}">
+                <input type="hidden" th:field="*{vendorMode}">
+                <input type="hidden" th:field="*{dateFrom}">
+                <input type="hidden" th:field="*{dateTo}">
+                <input type="hidden" th:field="*{status}">
+            </div>
+            <div class="col-md-4 d-flex gap-2">
+                <button type="submit" class="btn btn-dark flex-grow-1">
+                    <i class="bi bi-search me-1"></i>Search
+                </button>
+                <button type="button" class="btn btn-outline-secondary"
+                        data-bs-toggle="modal" data-bs-target="#advancedSearchModal">
+                    <i class="bi bi-funnel me-1"></i>Advanced
+                </button>
+            </div>
+        </div>
+    </form>
+
+    <div th:if="${criteria.isActive()}" class="d-flex justify-content-between align-items-center mb-2">
+        <span class="text-muted small"
+              th:text="|Filtered: ${page.totalElements} match(es)|">Filtered: 3 matches</span>
+        <a th:href="@{/purchase-orders}" class="btn btn-link btn-sm">
+            <i class="bi bi-x-circle me-1"></i>Clear filters
+        </a>
+    </div>
+
+    <!-- Purchase order list as table -->
     <table class="table">
         <thead>
             <tr>
                 <th th:replace="~{fragments/pagination :: sortHeader(label='Date', property='date', page=${page}, baseUrl='/purchase-orders')}"></th>
                 <th th:replace="~{fragments/pagination :: sortHeader(label='Purchase Order', property='id', page=${page}, baseUrl='/purchase-orders')}"></th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='Vendor', property='vendor.name', page=${page}, baseUrl='/purchase-orders')}"></th>
                 <th scope="col">Total</th>
                 <th th:replace="~{fragments/pagination :: sortHeader(label='Status', property='status', page=${page}, baseUrl='/purchase-orders')}"></th>
                 <th scope="col"></th>
@@ -65,6 +117,7 @@
             <tr th:each="purchaseOrder : ${page.content}">
                 <th scope="row" th:text="|${#temporals.monthNameShort(purchaseOrder.date)} ${#temporals.format(purchaseOrder.date, ' dd, yyyy')}|">1</th>
                 <td th:text="${purchaseOrder.id}">Mark</td>
+                <td th:text="${purchaseOrder.vendor != null ? purchaseOrder.vendor.name : ''}">Acme</td>
                 <td th:text="${#numbers.formatCurrency(purchaseOrder.total)}">$0</td>
                 <td th:text="${purchaseOrder.status.name()}">IN_TRANSIT</td>
                 <td><a th:href="@{/purchase-orders/{orderId}(orderId=${purchaseOrder.id})}" class="btn btn-outline-secondary">Details</a></td>
@@ -82,6 +135,73 @@
     <div th:replace="~{fragments/pagination :: pagination(page=${page}, baseUrl='/purchase-orders')}"></div>
 </div>
 
+<!-- ====== Advanced search modal ====== -->
+<div class="modal fade" id="advancedSearchModal" tabindex="-1" aria-labelledby="advancedSearchModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="advancedSearchModalLabel"><i class="bi bi-funnel me-2"></i>Advanced Search — Purchase Orders</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form th:action="@{/purchase-orders}" method="get" th:object="${criteria}">
+        <div class="modal-body">
+          <p class="text-muted small mb-3">Every field is optional — leave all blank to list every purchase order. Filters are AND-combined.</p>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">PO id</label>
+              <select class="form-select form-select-sm" th:field="*{idMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">starts with</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{id}" placeholder="e.g. 10">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Vendor name</label>
+              <select class="form-select form-select-sm" th:field="*{vendorMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{vendor}" placeholder="e.g. Apple">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Date from</label>
+              <input type="date" class="form-control" th:field="*{dateFrom}">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Date to</label>
+              <input type="date" class="form-control" th:field="*{dateTo}">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end">
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Status</label>
+              <select class="form-select" th:field="*{status}">
+                <option value="">— any —</option>
+                <option th:each="s : ${statuses}" th:value="${s}" th:text="${s.name()}">IN_TRANSIT</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-dark"><i class="bi bi-search me-1"></i>Search</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
 
 <!-- Header fragment -->
 <div th:insert="~{fragments/footer :: footer}"></div>


### PR DESCRIPTION
## Summary
- PR 5/6 in the Oracle-style advanced search rollout. The DTO (`AdvancedPoSearchCriteria`) and service `buildSpec` were already in place from Phase 0 (PR #22) and the original Oracle modal (PR #21) — this PR is wiring + UX only.
- `PurchaseOrderController.getAllPurchaseOrders` now binds `@ModelAttribute("criteria")` + `@PageableDefault(size=25, sort=\"date\" DESC)` and always calls `findAdvanced(criteria, pageable)`. Empty criteria → every PO, paginated. Also publishes `textModes` + `PoStatus` values for the modal selects.
- `/purchase-orders/pending` shares the template, so it also exposes those model attributes — keeps the pending-only list but lets the simple bar + Advanced modal render.
- `purchaseOrders.html` rewritten: simple bar bound to `criteria.id`, Advanced modal (id / vendor / date-range / status), Clear-filters chip, invalid-filter alert (reuses the `MethodArgumentTypeMismatchException` handler shipped in PR #26), and a new sortable **Vendor** column.
- `/goods-receipt-notes/search-purchase-order`: dropped the `if (criteria.isActive())` gate — always calls `findAdvanced`, so a fresh visit lists every PO paginated. The template gets sort headers + the shared pagination fragment.

## Test plan
- [x] `./mvnw test` — 32 tests, all green.
- [ ] Boot + visit `/purchase-orders` → 25 rows, page 1, descending by date.
- [ ] Open Advanced → pick **IN_TRANSIT** status → narrows; URL has `?status=IN_TRANSIT`.
- [ ] Add a vendor-name filter → narrows further; URL carries both params.
- [ ] Pick a date range → URL carries `dateFrom` + `dateTo`.
- [ ] Page 2 with filters → filters persist in URL.
- [ ] Sort header with filters → filters persist; page resets to 0.
- [ ] Reopen Advanced after a submit → fields pre-filled.
- [ ] `/purchase-orders?status=GARBAGE` → redirects to `?invalidFilter`, banner shown, full list renders.
- [ ] **Clear filters** → URL becomes `/purchase-orders`, full list returns.
- [ ] `/purchase-orders/pending` still shows the pending-only list.
- [ ] `/goods-receipt-notes/search-purchase-order` (no params) now shows every PO paginated (was empty before this PR). Filtering still narrows; the quick-lookup-by-id form at the top is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)