### PR TITLE
feat(autocomplete): add WAREHOUSE_SECTION suggestion source

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Services/SuggestionService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/SuggestionService.java
@@ -9,7 +9,8 @@ public interface SuggestionService {
         PURCHASE_ORDER,
         ITEM,
         CUSTOMER,
-        VENDOR
+        VENDOR,
+        WAREHOUSE_SECTION
     }
 
     enum Mode {

--- a/src/main/java/com/example/warehouseManagement/Services/SuggestionServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/SuggestionServiceImpl.java
@@ -10,10 +10,12 @@ import com.example.warehouseManagement.Domains.Customer;
 import com.example.warehouseManagement.Domains.Item;
 import com.example.warehouseManagement.Domains.PurchaseOrder;
 import com.example.warehouseManagement.Domains.Vendor;
+import com.example.warehouseManagement.Domains.WarehouseSection;
 import com.example.warehouseManagement.Repositories.CustomerRepository;
 import com.example.warehouseManagement.Repositories.ItemRepository;
 import com.example.warehouseManagement.Repositories.PurchaseOrderRepository;
 import com.example.warehouseManagement.Repositories.VendorRepository;
+import com.example.warehouseManagement.Repositories.WarehouseSectionRepository;
 
 import jakarta.annotation.PostConstruct;
 
@@ -31,17 +33,20 @@ public class SuggestionServiceImpl implements SuggestionService {
     private final ItemRepository itemRepository;
     private final CustomerRepository customerRepository;
     private final VendorRepository vendorRepository;
+    private final WarehouseSectionRepository warehouseSectionRepository;
 
     private final Map<Type, SuggestionIndex> indexes = new EnumMap<>(Type.class);
 
     public SuggestionServiceImpl(PurchaseOrderRepository purchaseOrderRepository,
                                  ItemRepository itemRepository,
                                  CustomerRepository customerRepository,
-                                 VendorRepository vendorRepository) {
+                                 VendorRepository vendorRepository,
+                                 WarehouseSectionRepository warehouseSectionRepository) {
         this.purchaseOrderRepository = purchaseOrderRepository;
         this.itemRepository = itemRepository;
         this.customerRepository = customerRepository;
         this.vendorRepository = vendorRepository;
+        this.warehouseSectionRepository = warehouseSectionRepository;
     }
 
     @PostConstruct
@@ -69,6 +74,11 @@ public class SuggestionServiceImpl implements SuggestionService {
         }
         for (Vendor v : vendorRepository.findAll()) {
             next.get(Type.VENDOR).add(v.getName(), v.getId());
+        }
+        for (WarehouseSection ws : warehouseSectionRepository.findAll()) {
+            // sectionNumber (e.g. "01-02-3-4") is the label the user types; id
+            // is included so any future href-template autocomplete can navigate.
+            next.get(Type.WAREHOUSE_SECTION).add(ws.getSectionNumber(), ws.getId());
         }
 
         indexes.clear();

--- a/src/main/resources/templates/putAwayTasks/searchWarehouseSectionForm.html
+++ b/src/main/resources/templates/putAwayTasks/searchWarehouseSectionForm.html
@@ -28,7 +28,11 @@
             <div class="col-12">
                 <label for="warehouseSection" class="form-label">Warehouse Section</label>
                 <input class="form-control" type="text" id="warehouseSection" th:field="*{warehouseSectionNumber}"
-                    name="salesOrder" required>
+                    name="salesOrder" required
+                    data-autocomplete-source="WAREHOUSE_SECTION"
+                    data-autocomplete-mode="CONTAINS"
+                    data-autocomplete-fill-on-select="true"
+                    autocomplete="off">
                 <div class="invalid-feedback">
                     Please enter the Warehouse Section
                 </div>


### PR DESCRIPTION
## Summary
- New autocomplete source for warehouse-section codes. `SuggestionService.Type` gains `WAREHOUSE_SECTION`; `SuggestionServiceImpl` injects `WarehouseSectionRepository` and indexes every section's `sectionNumber` (e.g. \`01-02-3-4\`) on warm-up / refresh.
- The **Put-away → By section** input now has `data-autocomplete-source=\"WAREHOUSE_SECTION\"` with `CONTAINS` mode and fill-on-select, matching the Customer / Vendor / Item simple-bar pattern. Staff can type a partial code and pick the match instead of recalling the full string.

## Test plan
- [x] \`./mvnw test\` — 32 tests, all green.
- [ ] Boot + visit \`/put-aways/search-warehouse-section\`, type \`01\` → dropdown lists matching sections.
- [ ] Pick a row → input fills with the section number; Enter submits the existing form unchanged.
- [ ] GET \`/api/suggestions?type=WAREHOUSE_SECTION&q=00&mode=CONTAINS\` returns JSON with at least the floor section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)