### PR TITLE
feat(picking-job): add advanced search modal to /picking-jobs list

### DIFF
--- a/src/main/java/com/example/warehouseManagement/Controllers/PickingJobController.java
+++ b/src/main/java/com/example/warehouseManagement/Controllers/PickingJobController.java
@@ -2,6 +2,9 @@ package com.example.warehouseManagement.Controllers;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,8 +14,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.example.warehouseManagement.Domains.PickingJob;
+import com.example.warehouseManagement.Domains.PickingJob.PjStatus;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedPickingJobSearchCriteria;
 import com.example.warehouseManagement.Domains.DTOs.PickingJobDto;
 import com.example.warehouseManagement.Domains.DTOs.PickingJobLineDto;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Services.InvoiceService;
 import com.example.warehouseManagement.Services.PickingJobService;
 import com.example.warehouseManagement.Services.PurchaseOrderService;
@@ -60,9 +66,14 @@ public class PickingJobController {
      * @return the name of the view template to render
      */
     @GetMapping
-    public String getAllPickingJobs(Model model) {
+    public String getAllPickingJobs(
+            @ModelAttribute("criteria") AdvancedPickingJobSearchCriteria criteria,
+            @PageableDefault(size = 25, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model) {
         model.addAttribute("title", "Picking Jobs");
-        model.addAttribute("pickingJobs", pickingJobService.findAllPending());
+        model.addAttribute("page", pickingJobService.findAdvanced(criteria, pageable));
+        model.addAttribute("textModes", TextMode.values());
+        model.addAttribute("statuses", PjStatus.values());
         return "pickingJobs/pickingJobs";
     }
 

--- a/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedPickingJobSearchCriteria.java
+++ b/src/main/java/com/example/warehouseManagement/Domains/DTOs/AdvancedPickingJobSearchCriteria.java
@@ -1,0 +1,51 @@
+package com.example.warehouseManagement.Domains.DTOs;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.example.warehouseManagement.Domains.PickingJob.PjStatus;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Filters bound from the Advanced Search modal on /picking-jobs. Every field
+ * is optional — null/blank means "ignore this filter" so a service call with
+ * an all-blank criteria returns every picking job (capped by Pageable).
+ */
+@Data
+@NoArgsConstructor
+public class AdvancedPickingJobSearchCriteria {
+
+    /** Picking job id as text — supports partial matches via {@link #idMode}. */
+    private String id;
+    private TextMode idMode = TextMode.STARTS_WITH;
+
+    /** Sales-order id — joined through {@code salesOrder.id}. */
+    private String salesOrderId;
+    private TextMode salesOrderIdMode = TextMode.STARTS_WITH;
+
+    /** Customer name match against PickingJob.salesOrder.customer.name. */
+    private String customer;
+    private TextMode customerMode = TextMode.CONTAINS;
+
+    /** Inclusive date range on PickingJob.date. */
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate dateFrom;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate dateTo;
+
+    /** Optional status. Null means "any status". */
+    private PjStatus status;
+
+    /** True when the user actually submitted the form with any filter set. */
+    public boolean isActive() {
+        return (id != null && !id.isBlank())
+                || (salesOrderId != null && !salesOrderId.isBlank())
+                || (customer != null && !customer.isBlank())
+                || dateFrom != null
+                || dateTo != null
+                || status != null;
+    }
+}

--- a/src/main/java/com/example/warehouseManagement/Repositories/PickingJobRepository.java
+++ b/src/main/java/com/example/warehouseManagement/Repositories/PickingJobRepository.java
@@ -1,17 +1,14 @@
 package com.example.warehouseManagement.Repositories;
 
-import java.util.List;
-
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import com.example.warehouseManagement.Domains.PickingJob;
 import com.example.warehouseManagement.Domains.PickingJob.PjStatus;
 
-public interface PickingJobRepository extends CrudRepository<PickingJob, Long> {
-    @Query(value = "SELECT * FROM picking_job pj\n" + //
-            "WHERE pj.status = 0 ORDER BY pj.date", nativeQuery = true)
-    public List<PickingJob> findAllPending();
+public interface PickingJobRepository
+        extends JpaRepository<PickingJob, Long>,
+                JpaSpecificationExecutor<PickingJob> {
 
     long countByStatus(PjStatus status);
 }

--- a/src/main/java/com/example/warehouseManagement/Services/PickingJobService.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PickingJobService.java
@@ -1,14 +1,21 @@
 package com.example.warehouseManagement.Services;
 
-import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import com.example.warehouseManagement.Domains.PickingJob;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedPickingJobSearchCriteria;
 import com.example.warehouseManagement.Domains.DTOs.PickingJobDto;
 
 public interface PickingJobService {
     public Iterable<PickingJob> findAll();
-    public List<PickingJob> findAllPending();
+    /**
+     * Advanced search — empty criteria returns every picking job, paginated.
+     * Spec returns cb.conjunction() when nothing is set.
+     */
+    Page<PickingJob> findAdvanced(AdvancedPickingJobSearchCriteria criteria, Pageable pageable);
     public Optional<PickingJob> findById(Long id);
     public PickingJob save(PickingJob pickingJob);
     public void delete(PickingJob pickingJob);

--- a/src/main/java/com/example/warehouseManagement/Services/PickingJobServiceImpl.java
+++ b/src/main/java/com/example/warehouseManagement/Services/PickingJobServiceImpl.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,13 +16,18 @@ import com.example.warehouseManagement.Domains.PickingJob.PjStatus;
 import com.example.warehouseManagement.Domains.PickingJobLine;
 import com.example.warehouseManagement.Domains.SalesOrder;
 import com.example.warehouseManagement.Domains.Stock;
+import com.example.warehouseManagement.Domains.DTOs.AdvancedPickingJobSearchCriteria;
 import com.example.warehouseManagement.Domains.DTOs.PickingJobDto;
+import com.example.warehouseManagement.Domains.DTOs.TextMode;
 import com.example.warehouseManagement.Repositories.BackorderRepository;
 import com.example.warehouseManagement.Repositories.PickingJobLineRepository;
 import com.example.warehouseManagement.Repositories.PickingJobRepository;
 import com.example.warehouseManagement.Repositories.SalesOrderRepository;
 import com.example.warehouseManagement.Repositories.StockRepository;
 import com.example.warehouseManagement.Repositories.WarehouseSectionRepository;
+
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
 
 @Service
 public class PickingJobServiceImpl implements PickingJobService {
@@ -70,8 +78,68 @@ public class PickingJobServiceImpl implements PickingJobService {
     }
 
     @Override
-    public List<PickingJob> findAllPending() {
-        return pickingJobRepository.findAllPending();
+    public Page<PickingJob> findAdvanced(AdvancedPickingJobSearchCriteria criteria, Pageable pageable) {
+        return pickingJobRepository.findAll(buildSpec(criteria), pageable);
+    }
+
+    private static Specification<PickingJob> buildSpec(AdvancedPickingJobSearchCriteria c) {
+        return (root, query, cb) -> {
+            List<Predicate> ps = new ArrayList<>();
+
+            if (c.getId() != null && !c.getId().isBlank()) {
+                String idStr = c.getId().trim();
+                TextMode mode = c.getIdMode() == null ? TextMode.STARTS_WITH : c.getIdMode();
+                if (mode == TextMode.EQUALS) {
+                    try {
+                        ps.add(cb.equal(root.get("id"), Long.parseLong(idStr)));
+                    } catch (NumberFormatException ignored) {
+                        ps.add(cb.disjunction());
+                    }
+                } else {
+                    Expression<String> idText = root.<Long>get("id").as(String.class);
+                    String pattern = (mode == TextMode.STARTS_WITH) ? idStr + "%" : "%" + idStr + "%";
+                    ps.add(cb.like(idText, pattern));
+                }
+            }
+
+            if (c.getSalesOrderId() != null && !c.getSalesOrderId().isBlank()) {
+                String soStr = c.getSalesOrderId().trim();
+                TextMode mode = c.getSalesOrderIdMode() == null ? TextMode.STARTS_WITH : c.getSalesOrderIdMode();
+                if (mode == TextMode.EQUALS) {
+                    try {
+                        ps.add(cb.equal(root.get("salesOrder").get("id"), Long.parseLong(soStr)));
+                    } catch (NumberFormatException ignored) {
+                        ps.add(cb.disjunction());
+                    }
+                } else {
+                    Expression<String> soText = root.get("salesOrder").<Long>get("id").as(String.class);
+                    String pattern = (mode == TextMode.STARTS_WITH) ? soStr + "%" : "%" + soStr + "%";
+                    ps.add(cb.like(soText, pattern));
+                }
+            }
+
+            if (c.getCustomer() != null && !c.getCustomer().isBlank()) {
+                String v = c.getCustomer().trim().toLowerCase();
+                Expression<String> customerName = cb.lower(root.get("salesOrder").get("customer").get("name"));
+                switch (c.getCustomerMode() == null ? TextMode.CONTAINS : c.getCustomerMode()) {
+                    case EQUALS      -> ps.add(cb.equal(customerName, v));
+                    case STARTS_WITH -> ps.add(cb.like(customerName, v + "%"));
+                    case CONTAINS    -> ps.add(cb.like(customerName, "%" + v + "%"));
+                }
+            }
+
+            if (c.getDateFrom() != null) {
+                ps.add(cb.greaterThanOrEqualTo(root.get("date"), c.getDateFrom()));
+            }
+            if (c.getDateTo() != null) {
+                ps.add(cb.lessThanOrEqualTo(root.get("date"), c.getDateTo()));
+            }
+            if (c.getStatus() != null) {
+                ps.add(cb.equal(root.get("status"), c.getStatus()));
+            }
+
+            return ps.isEmpty() ? cb.conjunction() : cb.and(ps.toArray(Predicate[]::new));
+        };
     }
 
     /**

--- a/src/main/resources/templates/pickingJobs/pickingJobs.html
+++ b/src/main/resources/templates/pickingJobs/pickingJobs.html
@@ -5,50 +5,178 @@
 <div th:insert="~{fragments/navbar :: navbar}"></div>
 
 <div class="container">
-    <!-- ALERTS TO PROVIDE USER FEEDBACK ON NOT FOUND PO -->
+    <!-- ALERTS TO PROVIDE USER FEEDBACK ON NOT FOUND PJ -->
     <div th:if="${param.notFound}">
         <div class="alert alert-info alert-dismissible fade show mt-3" role="alert">
             Picking Job not found
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
     </div>
-    <!-- ALERTS TO PROVIDE USER FEEDBACK ON SUCCESSFUL ADDED PO -->
+    <!-- ALERTS TO PROVIDE USER FEEDBACK ON SUCCESSFUL FULFILLED PJ -->
     <div th:if="${param.fulfilled}">
         <div class="alert alert-success alert-dismissible fade show mt-3" role="alert">
             Picking Job fulfilled
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
     </div>
-    <!-- Page headers -->
-    <h1 class="my-3" th:text="|Picking Jobs|">Picking JObs</h1>
-    <!-- Customer list as table -->
+    <!-- ALERT: invalid enum query param (e.g. ?status=GARBAGE) -->
+    <div th:if="${param.invalidFilter}">
+        <div class="alert alert-warning alert-dismissible fade show mt-3" role="alert">
+            One of the filter values was not recognized — showing every picking job.
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    </div>
+
+    <!-- Page header -->
+    <h1 class="my-3" th:text="${title}">Picking Jobs</h1>
+
+    <!-- Simple search bar (binds criteria.id) + Advanced button -->
+    <form th:action="@{/picking-jobs}" method="get" th:object="${criteria}" class="card shadow-sm mb-3">
+        <div class="card-body row g-2 align-items-end">
+            <div class="col-md-8">
+                <label class="form-label small mb-1">Search by picking-job id</label>
+                <input type="search" class="form-control" th:field="*{id}" placeholder="Type a picking job id...">
+                <input type="hidden" th:field="*{idMode}">
+                <input type="hidden" th:field="*{salesOrderId}">
+                <input type="hidden" th:field="*{salesOrderIdMode}">
+                <input type="hidden" th:field="*{customer}">
+                <input type="hidden" th:field="*{customerMode}">
+                <input type="hidden" th:field="*{dateFrom}">
+                <input type="hidden" th:field="*{dateTo}">
+                <input type="hidden" th:field="*{status}">
+            </div>
+            <div class="col-md-4 d-flex gap-2">
+                <button type="submit" class="btn btn-dark flex-grow-1">
+                    <i class="bi bi-search me-1"></i>Search
+                </button>
+                <button type="button" class="btn btn-outline-secondary"
+                        data-bs-toggle="modal" data-bs-target="#advancedSearchModal">
+                    <i class="bi bi-funnel me-1"></i>Advanced
+                </button>
+            </div>
+        </div>
+    </form>
+
+    <div th:if="${criteria.isActive()}" class="d-flex justify-content-between align-items-center mb-2">
+        <span class="text-muted small"
+              th:text="|Filtered: ${page.totalElements} match(es)|">Filtered: 3 matches</span>
+        <a th:href="@{/picking-jobs}" class="btn btn-link btn-sm">
+            <i class="bi bi-x-circle me-1"></i>Clear filters
+        </a>
+    </div>
+
+    <!-- Picking jobs list -->
     <table class="table">
         <thead>
             <tr>
-                <th scope="col">Date</th>
-                <th scope="col">Picking Job</th>
-                <th scope="col">Customer</th>
-                <th scope="col">Details</th>
-                <th scope="col">Fulfill</th>
-                <!-- <th scope="col"></th> -->
+                <th th:replace="~{fragments/pagination :: sortHeader(label='Date', property='date', page=${page}, baseUrl='/picking-jobs')}"></th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='Picking Job', property='id', page=${page}, baseUrl='/picking-jobs')}"></th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='Sales Order', property='salesOrder.id', page=${page}, baseUrl='/picking-jobs')}"></th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='Customer', property='salesOrder.customer.name', page=${page}, baseUrl='/picking-jobs')}"></th>
+                <th th:replace="~{fragments/pagination :: sortHeader(label='Status', property='status', page=${page}, baseUrl='/picking-jobs')}"></th>
+                <th scope="col"></th>
+                <th scope="col"></th>
             </tr>
         </thead>
         <tbody>
-            <tr th:each="pickingJob : ${pickingJobs}">
-                <th scope="row" th:text="|${#temporals.monthNameShort(pickingJob.date)} ${#temporals.format(pickingJob.date, ' dd, yyyy')}|">1</th>
-                <td th:text="${pickingJob.id}">Mark</td>
-                <td th:text="${pickingJob.salesOrder.customer.name}">Otto</td>
+            <tr th:each="pickingJob : ${page.content}">
+                <th scope="row" th:text="|${#temporals.monthNameShort(pickingJob.date)} ${#temporals.format(pickingJob.date, ' dd, yyyy')}|">May 15, 2026</th>
+                <td th:text="${pickingJob.id}">1</td>
+                <td th:text="${pickingJob.salesOrder != null ? pickingJob.salesOrder.id : ''}">42</td>
+                <td th:text="${pickingJob.salesOrder != null and pickingJob.salesOrder.customer != null ? pickingJob.salesOrder.customer.name : ''}">Acme</td>
+                <td><span class="badge bg-secondary" th:text="${pickingJob.status.name()}">PENDING</span></td>
                 <td><a th:href="@{/picking-jobs/{pickingJobId}(pickingJobId=${pickingJob.id})}" class="btn btn-outline-secondary">Details</a></td>
-                <td><a th:href="@{/picking-jobs/fulfill-job/{pickingJobId}(pickingJobId=${pickingJob.id})}" class="btn btn-outline-primary">Fulfill</a></td>
-                <!-- <td>
-                    <form th:action="@{/picking-job/{pickingJobId}(pickingJobId=${pickingJob.id})}" method="post">
-                        <button type="submit" class="btn btn-dark" name="delete">Delete</button>
-                    </form>
-                </td> -->
+                <td>
+                    <a th:if="${pickingJob.status.name() == 'PENDING'}"
+                       th:href="@{/picking-jobs/fulfill-job/{pickingJobId}(pickingJobId=${pickingJob.id})}"
+                       class="btn btn-outline-primary">Fulfill</a>
+                </td>
             </tr>
         </tbody>
     </table>
+    <div th:replace="~{fragments/pagination :: pagination(page=${page}, baseUrl='/picking-jobs')}"></div>
 </div>
 
-<!-- Header fragment -->
+<!-- ====== Advanced search modal ====== -->
+<div class="modal fade" id="advancedSearchModal" tabindex="-1" aria-labelledby="advancedSearchModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="advancedSearchModalLabel"><i class="bi bi-funnel me-2"></i>Advanced Search — Picking Jobs</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form th:action="@{/picking-jobs}" method="get" th:object="${criteria}">
+        <div class="modal-body">
+          <p class="text-muted small mb-3">Every field is optional — leave all blank to list every picking job. Filters are AND-combined.</p>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Picking Job id</label>
+              <select class="form-select form-select-sm" th:field="*{idMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">starts with</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{id}" placeholder="e.g. 10">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Sales Order id</label>
+              <select class="form-select form-select-sm" th:field="*{salesOrderIdMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">starts with</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{salesOrderId}" placeholder="e.g. 42">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-3">
+              <label class="form-label small mb-1">Customer name</label>
+              <select class="form-select form-select-sm" th:field="*{customerMode}">
+                <option th:each="m : ${textModes}" th:value="${m}" th:text="${m.name().replace('_', ' ').toLowerCase()}">contains</option>
+              </select>
+            </div>
+            <div class="col-md-9">
+              <label class="form-label small mb-1">&nbsp;</label>
+              <input type="text" class="form-control" th:field="*{customer}" placeholder="e.g. Acme">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Date from</label>
+              <input type="date" class="form-control" th:field="*{dateFrom}">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Date to</label>
+              <input type="date" class="form-control" th:field="*{dateTo}">
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-end">
+            <div class="col-md-6">
+              <label class="form-label small mb-1">Status</label>
+              <select class="form-select" th:field="*{status}">
+                <option value="">— any —</option>
+                <option th:each="s : ${statuses}" th:value="${s}" th:text="${s.name()}">PENDING</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-dark"><i class="bi bi-search me-1"></i>Search</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- Footer fragment -->
 <div th:insert="~{fragments/footer :: footer}"></div>


### PR DESCRIPTION
## Summary
- Applies the Oracle-style advanced-search pattern used on every other list page to **Picking Jobs**.
- `PickingJobRepository` upgraded from `CrudRepository` → `JpaRepository + JpaSpecificationExecutor`. The native `findAllPending()` query is dropped — Specification replaces it. `countByStatus` stays (dashboard KPI).
- New `AdvancedPickingJobSearchCriteria` DTO: id, salesOrderId, customer (joined via `salesOrder.customer.name`), status (`PjStatus`), date range + per-field `TextMode`.
- `PickingJobService.findAdvanced` + `buildSpec`; empty criteria returns `cb.conjunction()` so a fresh `/picking-jobs` visit lists every row paginated.
- `PickingJobController.getAllPickingJobs` binds `@ModelAttribute(\"criteria\")` + `@PageableDefault(size=25, sort=\"date\" DESC)`, publishes `textModes` + `PjStatus.values()`.
- `pickingJobs.html` rewritten: simple bar bound to `criteria.id`, Advanced modal (5 filter rows), sortable **Date / Picking Job / Sales Order / Customer / Status** columns, Clear-filters chip, invalid-filter alert (reuses PR #26's `MethodArgumentTypeMismatchException` handler), pagination fragment, Fulfill action restricted to PENDING rows.

### Behavior change worth flagging
\`/picking-jobs\` previously showed only **PENDING** rows. The new canonical list shows **every** status, descending by date. To recover the prior view, the navbar link could be updated to \`/picking-jobs?status=PENDING\` — left as a follow-up since the current navbar entry still works and only the rendered list is broader.

## Test plan
- [x] \`./mvnw test\` — 32 tests, all green.
- [ ] Boot + visit \`/picking-jobs\` → 25 rows, page 1, descending by date; mix of PENDING + FULFILLED visible.
- [ ] Open Advanced, pick **PENDING** status → narrows; URL \`?status=PENDING\`.
- [ ] Add a customer-name filter → narrows further; URL carries both.
- [ ] Pick a date range → URL carries \`dateFrom\` + \`dateTo\`.
- [ ] Page 2 with filters → filters persist.
- [ ] Sort header with filters → filters persist; page resets to 0.
- [ ] Reopen Advanced after submit → fields pre-filled.
- [ ] \`/picking-jobs?status=GARBAGE\` → redirect to \`?invalidFilter\`, banner shown, full list renders.
- [ ] **Clear filters** → URL becomes \`/picking-jobs\`, full list returns.
- [ ] Dashboard KPI for pending picking jobs still loads (uses retained \`countByStatus\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)